### PR TITLE
Re-enable alias parsers for Trunk Recorder

### DIFF
--- a/server/parsers.go
+++ b/server/parsers.go
@@ -380,6 +380,12 @@ func ParseMultipartContent(call *Call, p *multipart.Part, b []byte) {
 							// Also populate Meta.UnitRefs as fallback
 							call.Meta.UnitRefs = append(call.Meta.UnitRefs, unit.UnitRef)
 						}
+						switch s := v["tag"].(type) {
+						case string:
+							if len(s) > 0 {
+								call.Meta.UnitLabels = append(call.Meta.UnitLabels, s)
+							}
+						}
 						switch v := v["pos"].(type) {
 						case float64:
 							if v >= 0 {
@@ -578,6 +584,12 @@ func ParseTrunkRecorderMeta(call *Call, b []byte) error {
 					unit.UnitRef = uint(s)
 					// Also populate Meta.UnitRefs as fallback
 					call.Meta.UnitRefs = append(call.Meta.UnitRefs, unit.UnitRef)
+				}
+				switch s := v["tag"].(type) {
+				case string:
+					if len(s) > 0 {
+						call.Meta.UnitLabels = append(call.Meta.UnitLabels, s)
+					}
 				}
 				call.Units = append(call.Units, unit)
 			}


### PR DESCRIPTION
Rdio has historically had issues processing unit alias/tag data on API upload. The v7 branch appears to have been working towards a fix, but it has not been implemented across ingest points used by Trunk Recorder.  As ThinLine shares this codebase, this appears correctable by copy/pasting existing code into the other parsers.

This PR adds unit label extraction for the `sources` (multipart HTTP API) and `srcList` (TrunkRecorder JSON) parsers to match the existing `units` parser behavior. All three parsers now consistently extract unit IDs, offsets, and labels/tags into call metadata.

The Trunk Recorder plugin **does not** currently provide this data on upload, but preparing the server to handle it will lay the foundation for implementation in a later PR.  Correcting, and continuing to use the `sources` parser (instead of shifting to `units`) will ensure cross-compatibility for the plugin without creating a breaking change.

This will help address #47 and allow the future use of OTA aliases in call metadata.