### PR TITLE
Fix line endings in docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,8 @@ COPY --from=server-builder /build/server/thinline-radio .
 COPY docker-entrypoint.sh /app/
 RUN chmod +x /app/docker-entrypoint.sh
 
+RUN sed -i 's/\r$//' /app/docker-entrypoint.sh && chmod +x /app/docker-entrypoint.sh
+
 # Copy documentation (only essential files, optional ones can fail)
 COPY LICENSE README.md ./
 


### PR DESCRIPTION
Remove carriage return characters from the entrypoint script.