### PR TITLE
Chore: Format serverside code

### DIFF
--- a/server/access.go
+++ b/server/access.go
@@ -106,7 +106,7 @@ func (access *Access) HasAccess(call *Call) bool {
 					switch id := v["id"].(type) {
 					case float64:
 						systemRef := uint(id)
-						
+
 						// Get system ref from call (check multiple sources)
 						var callSystemRef uint
 						if call.System != nil {
@@ -117,7 +117,7 @@ func (access *Access) HasAccess(call *Call) bool {
 							// SystemId might be the ref in v6 compatibility mode
 							callSystemRef = call.SystemId
 						}
-						
+
 						// Check if systemRef matches
 						if callSystemRef > 0 && callSystemRef == systemRef {
 							switch tg := v["talkgroups"].(type) {
@@ -136,7 +136,7 @@ func (access *Access) HasAccess(call *Call) bool {
 									// TalkgroupId might be the ref in v6 compatibility mode
 									callTalkgroupRef = call.TalkgroupId
 								}
-								
+
 								for _, f := range tg {
 									switch tg := f.(type) {
 									case float64:
@@ -273,7 +273,7 @@ func (accesses *Accesses) Read(db *Database) error {
 		if strings.Contains(errStr, "does not exist") || strings.Contains(errStr, "relation") || strings.Contains(errStr, "Unknown table") {
 			log.Printf("WARNING: accesses table does not exist in Read(), attempting to create it...")
 			log.Printf("WARNING: Database: %s, Host: %s, Port: %d", db.Config.DbName, db.Config.DbHost, db.Config.DbPort)
-			
+
 			// Try to create the table - explicitly in public schema
 			var createQuery string
 			if db.Config.DbType == DbTypePostgresql {
@@ -531,4 +531,3 @@ func (accesses *Accesses) Write(db *Database) error {
 	log.Printf("DEBUG: Accesses.Write() completed - wrote %d access codes", len(accesses.List))
 	return nil
 }
-

--- a/server/admin.go
+++ b/server/admin.go
@@ -1455,13 +1455,13 @@ func (admin *Admin) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 					if err != nil {
 						logError(err)
 					} else {
-					// Restart transcription queue with updated settings
-					admin.Controller.RestartTranscriptionQueue()
+						// Restart transcription queue with updated settings
+						admin.Controller.RestartTranscriptionQueue()
 
-					// Restart no-audio monitoring in case health alert settings changed
-					go admin.Controller.StartNoAudioMonitoringForAllSystems()
+						// Restart no-audio monitoring in case health alert settings changed
+						go admin.Controller.StartNoAudioMonitoringForAllSystems()
 
-					// If audio encryption is enabled and we don't have a key yet
+						// If audio encryption is enabled and we don't have a key yet
 						// (or it was just enabled), fetch the key + client token from
 						// the relay server without requiring a server restart.
 						if admin.Controller.Options.AudioEncryptionEnabled &&
@@ -1769,22 +1769,22 @@ func (admin *Admin) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 			case []any:
 				// Only delete ALL existing users for full imports, not regular saves
 				if isFullImport {
-				allUsers := admin.Controller.Users.GetAllUsers()
-				for _, existingUser := range allUsers {
-					// Delete dependent rows first (FK constraints have no CASCADE after migration)
-					admin.Controller.Database.Sql.Exec(`DELETE FROM "userAlertPreferences" WHERE "userId" = $1`, existingUser.Id)
-					admin.Controller.Database.Sql.Exec(`DELETE FROM "deviceTokens" WHERE "userId" = $1`, existingUser.Id)
-					// Now safe to delete the user
-					_, err := admin.Controller.Database.Sql.Exec(`DELETE FROM "users" WHERE "userId" = $1`, existingUser.Id)
-					if err != nil {
-						logError(fmt.Errorf("failed to delete user %s from database during import: %v", existingUser.Email, err))
-					} else {
-						// Remove from in-memory map
-						if err := admin.Controller.Users.Remove(existingUser.Id); err != nil {
-							logError(fmt.Errorf("failed to remove user %s from memory during import: %v", existingUser.Email, err))
+					allUsers := admin.Controller.Users.GetAllUsers()
+					for _, existingUser := range allUsers {
+						// Delete dependent rows first (FK constraints have no CASCADE after migration)
+						admin.Controller.Database.Sql.Exec(`DELETE FROM "userAlertPreferences" WHERE "userId" = $1`, existingUser.Id)
+						admin.Controller.Database.Sql.Exec(`DELETE FROM "deviceTokens" WHERE "userId" = $1`, existingUser.Id)
+						// Now safe to delete the user
+						_, err := admin.Controller.Database.Sql.Exec(`DELETE FROM "users" WHERE "userId" = $1`, existingUser.Id)
+						if err != nil {
+							logError(fmt.Errorf("failed to delete user %s from database during import: %v", existingUser.Email, err))
+						} else {
+							// Remove from in-memory map
+							if err := admin.Controller.Users.Remove(existingUser.Id); err != nil {
+								logError(fmt.Errorf("failed to remove user %s from memory during import: %v", existingUser.Email, err))
+							}
 						}
 					}
-				}
 				}
 
 				// Now create/update users from import
@@ -2081,21 +2081,21 @@ func (admin *Admin) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 							}
 						}
 
-					// Use empty slices instead of nil so we always store "[]" not "null"
-					if keywords == nil {
-						keywords = []string{}
-					}
-					if keywordListIds == nil {
-						keywordListIds = []int{}
-					}
-					if toneSetIds == nil {
-						toneSetIds = []string{}
-					}
-					keywordsJson, _ := json.Marshal(keywords)
-					keywordListIdsJson, _ := json.Marshal(keywordListIds)
-					toneSetIdsJson, _ := json.Marshal(toneSetIds)
+						// Use empty slices instead of nil so we always store "[]" not "null"
+						if keywords == nil {
+							keywords = []string{}
+						}
+						if keywordListIds == nil {
+							keywordListIds = []int{}
+						}
+						if toneSetIds == nil {
+							toneSetIds = []string{}
+						}
+						keywordsJson, _ := json.Marshal(keywords)
+						keywordListIdsJson, _ := json.Marshal(keywordListIds)
+						toneSetIdsJson, _ := json.Marshal(toneSetIds)
 
-					// Insert user alert preference using parameterized queries
+						// Insert user alert preference using parameterized queries
 						if admin.Controller.Database.Config.DbType == DbTypePostgresql {
 							query := `INSERT INTO "userAlertPreferences" ("userId", "systemId", "talkgroupId", "alertEnabled", "toneAlerts", "keywordAlerts", "keywords", "keywordListIds", "toneSetIds") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 							if _, err := admin.Controller.Database.Sql.Exec(query, actualUserId, systemId, talkgroupId, alertEnabled, toneAlerts, keywordAlerts, string(keywordsJson), string(keywordListIdsJson), string(toneSetIdsJson)); err != nil {
@@ -2424,7 +2424,7 @@ func (admin *Admin) GetConfig() map[string]any {
 
 	// Get all user alert preferences from cache for export
 	userAlertPrefList := make([]map[string]any, 0)
-	
+
 	// We need to query the database for this as we don't have a method to get ALL preferences
 	// across ALL users from cache. This is acceptable as it's only for admin config export.
 	// Alternative: Could add GetAllPreferences() to cache, but export is rare operation.

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -6,43 +6,43 @@ import (
 
 func TestTalkgroupMatchesFilter(t *testing.T) {
 	admin := &Admin{}
-	
+
 	// Test talkgroup
 	tg := RadioReferenceTalkgroup{
 		Group: "Police",
 		Tag:   "Emergency",
 		Enc:   0,
 	}
-	
+
 	// Test with no filters
 	if !admin.talkgroupMatchesFilter(tg, "", "", nil) {
 		t.Error("Talkgroup should match when no filters are applied")
 	}
-	
+
 	// Test with group filter
 	if !admin.talkgroupMatchesFilter(tg, "Police", "", nil) {
 		t.Error("Talkgroup should match group filter 'Police'")
 	}
-	
+
 	if admin.talkgroupMatchesFilter(tg, "Fire", "", nil) {
 		t.Error("Talkgroup should not match group filter 'Fire'")
 	}
-	
+
 	// Test with tag filter
 	if !admin.talkgroupMatchesFilter(tg, "", "Emergency", nil) {
 		t.Error("Talkgroup should match tag filter 'Emergency'")
 	}
-	
+
 	if admin.talkgroupMatchesFilter(tg, "", "Traffic", nil) {
 		t.Error("Talkgroup should not match tag filter 'Traffic'")
 	}
-	
+
 	// Test with encrypted filter
 	encrypted := true
 	if admin.talkgroupMatchesFilter(tg, "", "", &encrypted) {
 		t.Error("Non-encrypted talkgroup should not match encrypted filter true")
 	}
-	
+
 	notEncrypted := false
 	if !admin.talkgroupMatchesFilter(tg, "", "", &notEncrypted) {
 		t.Error("Non-encrypted talkgroup should match encrypted filter false")
@@ -55,24 +55,24 @@ func TestPaginationCalculation(t *testing.T) {
 	pageSize := 100
 	startIndex := (page - 1) * pageSize
 	endIndex := startIndex + pageSize
-	
+
 	if startIndex != 0 {
 		t.Errorf("Expected startIndex 0, got %d", startIndex)
 	}
-	
+
 	if endIndex != 100 {
 		t.Errorf("Expected endIndex 100, got %d", endIndex)
 	}
-	
+
 	// Test second page
 	page = 2
 	startIndex = (page - 1) * pageSize
 	endIndex = startIndex + pageSize
-	
+
 	if startIndex != 100 {
 		t.Errorf("Expected startIndex 100, got %d", startIndex)
 	}
-	
+
 	if endIndex != 200 {
 		t.Errorf("Expected endIndex 200, got %d", endIndex)
 	}

--- a/server/alert_engine.go
+++ b/server/alert_engine.go
@@ -268,7 +268,7 @@ func (engine *AlertEngine) TriggerToneAlerts(call *Call) {
 		// This prevents duplicate alerts if the function is called multiple times
 		_, alertExists := engine.controller.RecentAlertsCache.AlertExists(
 			call.Id, call.System.Id, call.Talkgroup.Id, "tone", matchedToneSet.Id, "")
-		
+
 		if !alertExists {
 			// Create alert once for this tone set
 			engine.createAlert(&AlertRecord{
@@ -597,7 +597,7 @@ func (engine *AlertEngine) TriggerToneAndKeywordAlerts(call *Call, userId uint64
 		// Check if alert already exists for this call + tone set + keyword combination using cache
 		_, alertExists := engine.controller.RecentAlertsCache.AlertExists(
 			call.Id, call.System.Id, call.Talkgroup.Id, "tone+keyword", matchedToneSet.Id, keywordsJsonStr)
-		
+
 		if !alertExists {
 			// Create alert once for this tone set + keywords combination
 			engine.createAlert(&AlertRecord{
@@ -700,7 +700,7 @@ func (engine *AlertEngine) createAlert(alert *AlertRecord) {
 
 	// Add alert to cache for duplicate prevention
 	engine.controller.RecentAlertsCache.AddAlert(
-		alert.AlertId, alert.CallId, alert.SystemId, alert.TalkgroupId, 
+		alert.AlertId, alert.CallId, alert.SystemId, alert.TalkgroupId,
 		alert.AlertType, alert.ToneSetId, alert.KeywordsMatched)
 
 	// Debug log

--- a/server/api.go
+++ b/server/api.go
@@ -66,17 +66,17 @@ func (c *signupVerificationCache) Set(email, code string, expiryTime int64) {
 func (c *signupVerificationCache) Get(email string) (string, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	
+
 	code, exists := c.codes[email]
 	if !exists {
 		return "", false
 	}
-	
+
 	// Check if expired
 	if expiry, ok := c.expiry[email]; ok && time.Now().Unix() > expiry {
 		return "", false
 	}
-	
+
 	return code, true
 }
 
@@ -540,16 +540,16 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var request struct {
-		Email              string `json:"email"`
-		Password           string `json:"password"`
-		FirstName          string `json:"firstName"`
-		LastName           string `json:"lastName"`
-		ZipCode            string `json:"zipCode"`
-		RegistrationCode   string `json:"registrationCode"` // Deprecated: use accessCode
-		InvitationCode     string `json:"invitationCode"`   // Deprecated: use accessCode
-		AccessCode         string `json:"accessCode"`       // Unified field for both invitation and registration codes
-		TurnstileToken     string `json:"turnstile_token"`
-		VerificationCode   string `json:"verificationCode"` // Email verification code (if emailVerificationRequired)
+		Email            string `json:"email"`
+		Password         string `json:"password"`
+		FirstName        string `json:"firstName"`
+		LastName         string `json:"lastName"`
+		ZipCode          string `json:"zipCode"`
+		RegistrationCode string `json:"registrationCode"` // Deprecated: use accessCode
+		InvitationCode   string `json:"invitationCode"`   // Deprecated: use accessCode
+		AccessCode       string `json:"accessCode"`       // Unified field for both invitation and registration codes
+		TurnstileToken   string `json:"turnstile_token"`
+		VerificationCode string `json:"verificationCode"` // Email verification code (if emailVerificationRequired)
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
@@ -3357,7 +3357,7 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 	case http.MethodGet:
 		// Get preferences from cache
 		cachedPrefs := api.Controller.PreferencesCache.GetUserPreferences(client.User.Id)
-		
+
 		preferences := []map[string]any{}
 		for _, pref := range cachedPrefs {
 			// Look up systemRef and talkgroupRef from in-memory Systems
@@ -3369,21 +3369,21 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 
-		prefMap := map[string]any{
-			"userId":               pref.UserId,
-			"systemId":             pref.SystemId,
-			"talkgroupId":          pref.TalkgroupId,
-			"alertEnabled":         pref.AlertEnabled,
-			"toneAlerts":           pref.ToneAlerts,
-			"keywordAlerts":        pref.KeywordAlerts,
-			"keywords":             pref.Keywords,
-			"keywordListIds":       pref.KeywordListIds,
-			"toneSetIds":           pref.ToneSetIds,
-			"notificationSound":    pref.NotificationSound,
-			"toneSetSounds":        pref.ToneSetSounds,
-			"pagerAlert":           pref.PagerAlert,
-			"toneSetPagerAlerts":   pref.ToneSetPagerAlerts,
-		}
+			prefMap := map[string]any{
+				"userId":             pref.UserId,
+				"systemId":           pref.SystemId,
+				"talkgroupId":        pref.TalkgroupId,
+				"alertEnabled":       pref.AlertEnabled,
+				"toneAlerts":         pref.ToneAlerts,
+				"keywordAlerts":      pref.KeywordAlerts,
+				"keywords":           pref.Keywords,
+				"keywordListIds":     pref.KeywordListIds,
+				"toneSetIds":         pref.ToneSetIds,
+				"notificationSound":  pref.NotificationSound,
+				"toneSetSounds":      pref.ToneSetSounds,
+				"pagerAlert":         pref.PagerAlert,
+				"toneSetPagerAlerts": pref.ToneSetPagerAlerts,
+			}
 
 			// Include systemRef and talkgroupRef for frontend matching
 			if systemRef > 0 {
@@ -3419,21 +3419,21 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 		defer tx.Rollback()
 
 		for _, pref := range preferences {
-		var (
-			requestSystem      uint64
-			requestTg          uint64
-			systemId           uint64
-			alertEnabled       bool
-			toneAlerts         bool = true
-			keywordAlerts      bool = true
-			keywords           []string
-			keywordListIds     []uint64
-			toneSetIds         []string
-			notificationSound  string
-			toneSetSounds      map[string]string
-			pagerAlert         bool
-			toneSetPagerAlerts map[string]bool
-		)
+			var (
+				requestSystem      uint64
+				requestTg          uint64
+				systemId           uint64
+				alertEnabled       bool
+				toneAlerts         bool = true
+				keywordAlerts      bool = true
+				keywords           []string
+				keywordListIds     []uint64
+				toneSetIds         []string
+				notificationSound  string
+				toneSetSounds      map[string]string
+				pagerAlert         bool
+				toneSetPagerAlerts map[string]bool
+			)
 
 			// Accept either systemRef or systemId field names — prefer systemRef
 			// since the resolution logic queries by systemRef column first,
@@ -3546,28 +3546,28 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 				toneAlerts = false
 			}
 
-		keywordsJson, _ := json.Marshal(keywords)
-		keywordListIdsJson, _ := json.Marshal(keywordListIds)
-		toneSetIdsJson, _ := json.Marshal(toneSetIds)
-		toneSetSoundsJson, _ := json.Marshal(toneSetSounds)
-		toneSetPagerAlertsJson, _ := json.Marshal(toneSetPagerAlerts)
+			keywordsJson, _ := json.Marshal(keywords)
+			keywordListIdsJson, _ := json.Marshal(keywordListIds)
+			toneSetIdsJson, _ := json.Marshal(toneSetIds)
+			toneSetSoundsJson, _ := json.Marshal(toneSetSounds)
+			toneSetPagerAlertsJson, _ := json.Marshal(toneSetPagerAlerts)
 
-		// Ensure we never store "null" for arrays/objects
-		if string(keywordsJson) == "null" {
-			keywordsJson = []byte("[]")
-		}
-		if string(keywordListIdsJson) == "null" {
-			keywordListIdsJson = []byte("[]")
-		}
-		if string(toneSetIdsJson) == "null" {
-			toneSetIdsJson = []byte("[]")
-		}
-		if string(toneSetSoundsJson) == "null" {
-			toneSetSoundsJson = []byte("{}")
-		}
-		if string(toneSetPagerAlertsJson) == "null" {
-			toneSetPagerAlertsJson = []byte("{}")
-		}
+			// Ensure we never store "null" for arrays/objects
+			if string(keywordsJson) == "null" {
+				keywordsJson = []byte("[]")
+			}
+			if string(keywordListIdsJson) == "null" {
+				keywordListIdsJson = []byte("[]")
+			}
+			if string(toneSetIdsJson) == "null" {
+				toneSetIdsJson = []byte("[]")
+			}
+			if string(toneSetSoundsJson) == "null" {
+				toneSetSoundsJson = []byte("{}")
+			}
+			if string(toneSetPagerAlertsJson) == "null" {
+				toneSetPagerAlertsJson = []byte("{}")
+			}
 
 			// DEBUG: Log tone set preferences being saved
 			if toneAlerts {
@@ -3581,10 +3581,10 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 				api.Controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("💾 [TONE SET DEBUG] Saving preference for user %d, system %d, talkgroup %d: toneAlerts=false (only keyword alerts)", client.User.Id, systemId, dbTalkgroupId))
 			}
 
-		// Upsert preference using verified database talkgroupId
-		query := fmt.Sprintf(`INSERT INTO "userAlertPreferences" ("userId", "systemId", "talkgroupId", "alertEnabled", "toneAlerts", "keywordAlerts", "keywords", "keywordListIds", "toneSetIds", "notificationSound", "toneSetSounds", "pagerAlert", "toneSetPagerAlerts") VALUES (%d, %d, %d, %t, %t, %t, $1, $2, $3, $4, $5, %t, $6) ON CONFLICT ("userId", "systemId", "talkgroupId") DO UPDATE SET "alertEnabled" = %t, "toneAlerts" = %t, "keywordAlerts" = %t, "keywords" = $1, "keywordListIds" = $2, "toneSetIds" = $3, "notificationSound" = $4, "toneSetSounds" = $5, "pagerAlert" = %t, "toneSetPagerAlerts" = $6`, client.User.Id, systemId, dbTalkgroupId, alertEnabled, toneAlerts, keywordAlerts, pagerAlert, alertEnabled, toneAlerts, keywordAlerts, pagerAlert)
+			// Upsert preference using verified database talkgroupId
+			query := fmt.Sprintf(`INSERT INTO "userAlertPreferences" ("userId", "systemId", "talkgroupId", "alertEnabled", "toneAlerts", "keywordAlerts", "keywords", "keywordListIds", "toneSetIds", "notificationSound", "toneSetSounds", "pagerAlert", "toneSetPagerAlerts") VALUES (%d, %d, %d, %t, %t, %t, $1, $2, $3, $4, $5, %t, $6) ON CONFLICT ("userId", "systemId", "talkgroupId") DO UPDATE SET "alertEnabled" = %t, "toneAlerts" = %t, "keywordAlerts" = %t, "keywords" = $1, "keywordListIds" = $2, "toneSetIds" = $3, "notificationSound" = $4, "toneSetSounds" = $5, "pagerAlert" = %t, "toneSetPagerAlerts" = $6`, client.User.Id, systemId, dbTalkgroupId, alertEnabled, toneAlerts, keywordAlerts, pagerAlert, alertEnabled, toneAlerts, keywordAlerts, pagerAlert)
 
-		if _, err := tx.Exec(query, string(keywordsJson), string(keywordListIdsJson), string(toneSetIdsJson), notificationSound, string(toneSetSoundsJson), string(toneSetPagerAlertsJson)); err != nil {
+			if _, err := tx.Exec(query, string(keywordsJson), string(keywordListIdsJson), string(toneSetIdsJson), notificationSound, string(toneSetSoundsJson), string(toneSetPagerAlertsJson)); err != nil {
 				api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to update preference: %v", err))
 				return
 			}
@@ -3627,7 +3627,7 @@ func (api *Api) KeywordListsHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		// Get all keyword lists from cache
 		cachedLists := api.Controller.KeywordListsCache.GetAllLists()
-		
+
 		lists := []map[string]any{}
 		for _, list := range cachedLists {
 			lists = append(lists, map[string]any{
@@ -3693,12 +3693,12 @@ func (api *Api) KeywordListsHandler(w http.ResponseWriter, r *http.Request) {
 			api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create keyword list: %v", err))
 			return
 		}
-		
+
 		// Reload keyword lists cache after creation
 		if err := api.Controller.KeywordListsCache.Read(api.Controller.Database); err != nil {
 			api.Controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("failed to reload keyword lists cache after create: %v", err))
 		}
-		
+
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(fmt.Sprintf(`{"id": %d, "success": true}`, listId)))
 

--- a/server/apikey.go
+++ b/server/apikey.go
@@ -222,7 +222,7 @@ func (apikeys *Apikeys) Read(db *Database) error {
 			enabledCount++
 		}
 	}
-	fmt.Printf("Apikeys.Read: loaded %d total API keys (%d enabled, %d disabled)\n", 
+	fmt.Printf("Apikeys.Read: loaded %d total API keys (%d enabled, %d disabled)\n",
 		len(apikeys.List), enabledCount, disabledCount)
 	if len(apikeys.List) == 0 {
 		fmt.Printf("Apikeys.Read: WARNING - No API keys found in database. Upload sources (SDRTrunk, etc.) will not be able to connect.\n")

--- a/server/cache.go
+++ b/server/cache.go
@@ -298,8 +298,8 @@ func (cache *KeywordListsCache) GetAllLists() []*KeywordList {
 // ============================================================================
 
 type IdLookupsCache struct {
-	systemRefToId    map[uint]uint64    // systemRef -> systemId
-	talkgroupRefToId map[uint64]uint64  // composite key -> talkgroupId
+	systemRefToId    map[uint]uint64   // systemRef -> systemId
+	talkgroupRefToId map[uint64]uint64 // composite key -> talkgroupId
 	mutex            sync.RWMutex
 	controller       *Controller
 }
@@ -366,7 +366,7 @@ func (cache *IdLookupsCache) Read(db *Database) error {
 	}
 
 	if cache.controller != nil && cache.controller.Logs != nil {
-		cache.controller.Logs.LogEvent(LogLevelInfo, 
+		cache.controller.Logs.LogEvent(LogLevelInfo,
 			fmt.Sprintf("✅ Loaded %d system and %d talkgroup ID mappings into cache", systemCount, talkgroupCount))
 	}
 
@@ -417,10 +417,10 @@ func NewRecentAlertsCache(controller *Controller) *RecentAlertsCache {
 		alerts:     make(map[string]*AlertCacheEntry),
 		controller: controller,
 	}
-	
+
 	// Start cleanup goroutine to remove old entries
 	go cache.cleanup()
-	
+
 	return cache
 }
 

--- a/server/call.go
+++ b/server/call.go
@@ -397,8 +397,6 @@ const audioFingerprintWindow = 120 * time.Second
 // duplicate detection when the admin has not configured DuplicateTimestampWindow.
 const defaultTimestampFallbackWindow = 800 * time.Millisecond
 
-
-
 // CheckDuplicateByHash queries the DB for any call on the same system+talkgroup
 // whose PCM content hash matches this call's hash. A hash match means the decoded
 // audio samples are bit-identical — a guaranteed duplicate regardless of how far
@@ -476,7 +474,6 @@ func (calls *Calls) CheckDuplicateByTimestamp(call *Call, db *Database, windowMs
 
 	return false, nil
 }
-
 
 func (calls *Calls) GetCall(id uint64) (*Call, error) {
 	var (
@@ -618,12 +615,12 @@ func (calls *Calls) GetCall(id uint64) (*Call, error) {
 
 // GetCallsBulk fetches multiple calls in 3 queries instead of N×2 round-trips.
 //
-//  Query 1 — metadata + patches (no audio blob; avoids GROUP BY on blobs):
-//            callId, timestamp, patches, systemId, talkgroupId, frequency,
-//            toneSequence, hasTones, transcript, transcriptConfidence,
-//            transcriptionStatus, alertSummary
-//  Query 2 — audio bytes + filenames: callId, audio, audioFilename, audioMime, siteRef
-//  Query 3 — units:                   callId, offset, unitRef, label
+//	Query 1 — metadata + patches (no audio blob; avoids GROUP BY on blobs):
+//	          callId, timestamp, patches, systemId, talkgroupId, frequency,
+//	          toneSequence, hasTones, transcript, transcriptConfidence,
+//	          transcriptionStatus, alertSummary
+//	Query 2 — audio bytes + filenames: callId, audio, audioFilename, audioMime, siteRef
+//	Query 3 — units:                   callId, offset, unitRef, label
 //
 // Any IDs currently in the delay queue are silently skipped.
 func (calls *Calls) GetCallsBulk(ids []uint64) []*Call {
@@ -740,7 +737,7 @@ func (calls *Calls) GetCallsBulk(ids []uint64) []*Call {
 
 	// --- Query 2: audio blobs ---
 	audioRows, err := calls.controller.Database.Sql.Query(
-		`SELECT "callId", "audio", "audioFilename", "audioMime", "siteRef" FROM "calls" WHERE "callId" IN (`+inClause+`)`)
+		`SELECT "callId", "audio", "audioFilename", "audioMime", "siteRef" FROM "calls" WHERE "callId" IN (` + inClause + `)`)
 	if err == nil {
 		defer audioRows.Close()
 		for audioRows.Next() {
@@ -760,7 +757,7 @@ func (calls *Calls) GetCallsBulk(ids []uint64) []*Call {
 
 	// --- Query 3: units ---
 	unitRows, err := calls.controller.Database.Sql.Query(
-		`SELECT "callId", "offset", "unitRef", COALESCE("label", '') FROM "callUnits" WHERE "callId" IN (`+inClause+`) ORDER BY "callId", "offset" ASC`)
+		`SELECT "callId", "offset", "unitRef", COALESCE("label", '') FROM "callUnits" WHERE "callId" IN (` + inClause + `) ORDER BY "callId", "offset" ASC`)
 	if err == nil {
 		defer unitRows.Close()
 		for unitRows.Next() {

--- a/server/client.go
+++ b/server/client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-
 type Client struct {
 	User        *User
 	AuthCount   int
@@ -131,12 +130,12 @@ func (client *Client) Init(controller *Controller, request *http.Request, conn *
 				var userSettings map[string]interface{}
 				if user.Settings != "" {
 					if err := json.Unmarshal([]byte(user.Settings), &userSettings); err == nil {
-					if enabled, ok := userSettings["disconnectAlertPushEnabled"].(bool); ok && enabled {
-						go func() {
-							time.Sleep(10 * time.Second)
-							ctrl.sendDisconnectPushNotificationToDevice(user, fcmToken)
-						}()
-					}
+						if enabled, ok := userSettings["disconnectAlertPushEnabled"].(bool); ok && enabled {
+							go func() {
+								time.Sleep(10 * time.Second)
+								ctrl.sendDisconnectPushNotificationToDevice(user, fcmToken)
+							}()
+						}
 					}
 				}
 			}
@@ -222,36 +221,36 @@ func (client *Client) Init(controller *Controller, request *http.Request, conn *
 					}
 				}
 
-			var b []byte
-			var jsonErr error
+				var b []byte
+				var jsonErr error
 
-			// When audio encryption is enabled and this is a call message, encrypt
-			// the audio exactly once (sync.Once guards concurrent client goroutines)
-			// and cache the wire bytes on the message so every listener reuses the
-			// same ciphertext. Memory is freed when the last channel reference drops.
-			if message.Command == MessageCommandCall && len(controller.AudioKey) == 32 {
-				if call, ok := message.Payload.(*Call); ok {
-					audioKey := controller.AudioKey
-					message.encryptOnce.Do(func() {
-						var enc []byte
-						enc, jsonErr = call.MarshalJSONWithEncryption(audioKey)
-						if jsonErr == nil {
-							envelope := []any{message.Command, json.RawMessage(enc)}
-							if message.Flag != nil && message.Flag != "" {
-								envelope = append(envelope, message.Flag)
+				// When audio encryption is enabled and this is a call message, encrypt
+				// the audio exactly once (sync.Once guards concurrent client goroutines)
+				// and cache the wire bytes on the message so every listener reuses the
+				// same ciphertext. Memory is freed when the last channel reference drops.
+				if message.Command == MessageCommandCall && len(controller.AudioKey) == 32 {
+					if call, ok := message.Payload.(*Call); ok {
+						audioKey := controller.AudioKey
+						message.encryptOnce.Do(func() {
+							var enc []byte
+							enc, jsonErr = call.MarshalJSONWithEncryption(audioKey)
+							if jsonErr == nil {
+								envelope := []any{message.Command, json.RawMessage(enc)}
+								if message.Flag != nil && message.Flag != "" {
+									envelope = append(envelope, message.Flag)
+								}
+								enc, jsonErr = json.Marshal(envelope)
 							}
-							enc, jsonErr = json.Marshal(envelope)
-						}
-						if jsonErr == nil {
-							message.encryptedJSON = enc
-						}
-					})
-					b = message.encryptedJSON
+							if jsonErr == nil {
+								message.encryptedJSON = enc
+							}
+						})
+						b = message.encryptedJSON
+					}
 				}
-			}
-			if b == nil && jsonErr == nil {
-				b, jsonErr = message.ToJson()
-			}
+				if b == nil && jsonErr == nil {
+					b, jsonErr = message.ToJson()
+				}
 
 				if jsonErr != nil {
 					controller.Logs.LogEvent(LogLevelError, fmt.Sprintf("client.message.tojson error for ip %s: %v", client.GetRemoteAddr(), jsonErr))

--- a/server/config.go
+++ b/server/config.go
@@ -34,25 +34,25 @@ const (
 )
 
 type Config struct {
-	BaseDir              string
-	ConfigFile           string
-	DbType               string
-	DbHost               string
-	DbPort               uint
-	DbName               string
-	DbUsername           string
-	DbPassword           string
-	Listen               string
-	SslAutoCert          string
-	SslCaCertFile        string
-	SslCaKeyFile         string
-	SslCertFile          string
-	SslKeyFile           string
-	SslListen            string
-	EnableDebugLog       bool
-	AutoUpdate           bool   // Automatically check and apply updates from GitHub
-	daemon               *Daemon
-	newAdminPassword     string
+	BaseDir          string
+	ConfigFile       string
+	DbType           string
+	DbHost           string
+	DbPort           uint
+	DbName           string
+	DbUsername       string
+	DbPassword       string
+	Listen           string
+	SslAutoCert      string
+	SslCaCertFile    string
+	SslCaKeyFile     string
+	SslCertFile      string
+	SslKeyFile       string
+	SslListen        string
+	EnableDebugLog   bool
+	AutoUpdate       bool // Automatically check and apply updates from GitHub
+	daemon           *Daemon
+	newAdminPassword string
 }
 
 func NewConfig() *Config {
@@ -173,16 +173,16 @@ func NewConfig() *Config {
 				config.SslListen = v
 			}
 
-		// Read enable_debug_log option (defaults to false)
-		if v, err := cfg.Section("").Key("enable_debug_log").Bool(); err == nil {
-			config.EnableDebugLog = v
-		}
+			// Read enable_debug_log option (defaults to false)
+			if v, err := cfg.Section("").Key("enable_debug_log").Bool(); err == nil {
+				config.EnableDebugLog = v
+			}
 
-		// Read auto_update setting (defaults to false)
-		if v, err := cfg.Section("").Key("auto_update").Bool(); err == nil {
-			config.AutoUpdate = v
+			// Read auto_update setting (defaults to false)
+			if v, err := cfg.Section("").Key("auto_update").Bool(); err == nil {
+				config.AutoUpdate = v
+			}
 		}
-	}
 
 		if config.DbType != DbTypePostgresql {
 			fmt.Printf("unknown database type %s (only postgresql is supported)\n", config.DbType)

--- a/server/controller.go
+++ b/server/controller.go
@@ -71,18 +71,18 @@ type Controller struct {
 	HallucinationDetector            *HallucinationDetector
 	CentralManagement                *CentralManagementService
 	// Performance caches
-	PreferencesCache                 *PreferencesCache
-	KeywordListsCache                *KeywordListsCache
-	IdLookupsCache                   *IdLookupsCache
-	RecentAlertsCache                *RecentAlertsCache
-	DedupCache                       *DedupCache
-	Register                         chan *Client
-	Unregister                       chan *Client
-	Ingest                           chan *Call
-	running                          bool
-	workerCancel                     context.CancelFunc // Function to cancel worker context
-	workersWg                        sync.WaitGroup     // WaitGroup to track worker goroutines
-	workerStats                      struct {
+	PreferencesCache  *PreferencesCache
+	KeywordListsCache *KeywordListsCache
+	IdLookupsCache    *IdLookupsCache
+	RecentAlertsCache *RecentAlertsCache
+	DedupCache        *DedupCache
+	Register          chan *Client
+	Unregister        chan *Client
+	Ingest            chan *Call
+	running           bool
+	workerCancel      context.CancelFunc // Function to cancel worker context
+	workersWg         sync.WaitGroup     // WaitGroup to track worker goroutines
+	workerStats       struct {
 		sync.Mutex
 		activeWorkers  int
 		totalCalls     int64
@@ -505,13 +505,13 @@ func (controller *Controller) IngestCall(call *Call) {
 			}
 
 			talkgroup = &Talkgroup{
-				GroupIds:        []uint64{groupId},
-				Label:           fmt.Sprintf("%d", talkgroupId),
-				Name:            fmt.Sprintf("%d", talkgroupId),
-				TalkgroupRef:    talkgroupId,
-				TagId:           tagId,
-				Order:           maxOrder + 1, // Assign order at the end of the list
-				AlertsEnabled:   system.AutoPopulateAlertsEnabled,
+				GroupIds:      []uint64{groupId},
+				Label:         fmt.Sprintf("%d", talkgroupId),
+				Name:          fmt.Sprintf("%d", talkgroupId),
+				TalkgroupRef:  talkgroupId,
+				TagId:         tagId,
+				Order:         maxOrder + 1, // Assign order at the end of the list
+				AlertsEnabled: system.AutoPopulateAlertsEnabled,
 			}
 
 			// Update label and name if provided (v6 style)
@@ -863,7 +863,6 @@ func (controller *Controller) processCallAfterDuplicateCheck(call *Call) {
 				})
 			}
 		}
-
 
 		if !call.IsDuplicate {
 			// IMMEDIATE: Emit call to clients (users can play NOW - zero delay)

--- a/server/debug_logger.go
+++ b/server/debug_logger.go
@@ -180,10 +180,10 @@ func (d *DebugLogger) Close() {
 	d.mutex.Lock()
 	d.closed = true
 	d.mutex.Unlock()
-	
+
 	// Small delay to let any in-flight writes complete
 	time.Sleep(100 * time.Millisecond)
-	
+
 	// Write final message and close file (no mutex needed, writes will be rejected now)
 	if d.file != nil {
 		timestamp := time.Now().Format("2006-01-02 15:04:05.000")
@@ -244,10 +244,10 @@ func (t *TranscriptionDebugLogger) Close() {
 	t.mutex.Lock()
 	t.closed = true
 	t.mutex.Unlock()
-	
+
 	// Small delay to let any in-flight writes complete
 	time.Sleep(100 * time.Millisecond)
-	
+
 	// Write final message and close file
 	if t.file != nil {
 		timestamp := time.Now().Format("2006-01-02 15:04:05.000")

--- a/server/dedup_cache.go
+++ b/server/dedup_cache.go
@@ -24,8 +24,8 @@ import (
 // DedupEntry caches metadata for a recently seen call to catch simultaneous
 // duplicate arrivals before either has been written to the DB.
 type DedupEntry struct {
-	Duration      float64   // Audio duration in seconds (for ratio guard)
-	CallTimestamp int64     // P25 call timestamp in milliseconds
+	Duration      float64 // Audio duration in seconds (for ratio guard)
+	CallTimestamp int64   // P25 call timestamp in milliseconds
 	SeenAt        time.Time
 }
 
@@ -34,9 +34,10 @@ type DedupEntry struct {
 // before either has been written.
 //
 // Key prefixes:
-//   "ep:systemId:talkgroupId" — energy profile entry
-//   "ah:systemId:talkgroupId:hash" — PCM content hash entry
-//   "ts:systemId:talkgroupId" — timestamp fallback entry
+//
+//	"ep:systemId:talkgroupId" — energy profile entry
+//	"ah:systemId:talkgroupId:hash" — PCM content hash entry
+//	"ts:systemId:talkgroupId" — timestamp fallback entry
 //
 // A background goroutine evicts stale entries every 30 seconds.
 type DedupCache struct {
@@ -59,7 +60,6 @@ func NewDedupCache(timeframeMs uint) *DedupCache {
 	go dc.evictionLoop()
 	return dc
 }
-
 
 // CheckAndMarkHash checks a PCM content hash against the cache. Returns true if
 // an identical hash was already seen for this system+talkgroup (exact duplicate).

--- a/server/defaults.go
+++ b/server/defaults.go
@@ -45,93 +45,93 @@ type DefaultDownstream struct {
 }
 
 type DefaultOptions struct {
-	autoPopulate                bool
-	audioConversion             uint
-	branding                    string
-	defaultSystemDelay          uint
-	disableDuplicateDetection   bool
-	duplicateDetectionTimeFrame uint
-	duplicateTimestampWindow    uint
-	email                       string
-	keypadBeeps                 string
-	maxClients                  uint
-	playbackGoesLive            bool
-	pruneDays                   uint
-	showListenersCount          bool
-	sortTalkgroups              bool
-	time12hFormat               bool
-	radioReferenceEnabled       bool
-	radioReferenceUsername      string
-	radioReferencePassword      string
-	userRegistrationEnabled     bool
-	publicRegistrationEnabled   bool
-	publicRegistrationMode      string
-	emailVerificationRequired   bool
-	stripePaywallEnabled        bool
-	emailServiceEnabled         bool
-	emailServiceApiKey          string
-	emailServiceDomain          string
-	emailServiceTemplateId      string
-	emailProvider               string
-	emailSendGridAPIKey         string
-	emailMailgunAPIKey          string
-	emailMailgunDomain          string
-	emailMailgunAPIBase         string
-	emailSmtpHost               string
-	emailSmtpPort               int
-	emailSmtpUsername           string
-	emailSmtpPassword           string
-	emailSmtpUseTLS             bool
-	emailSmtpSkipVerify         bool
-	emailSmtpFromEmail          string
-	emailSmtpFromName           string
-	emailLogoFilename           string
-	emailLogoBorderRadius       string
-	faviconFilename             string
-	stripePublishableKey        string
-	stripeSecretKey             string
-	stripeWebhookSecret         string
-	stripeGracePeriodDays        uint
-	stripePriceId               string
-	baseUrl                     string
-	transcriptionConfig         DefaultTranscriptionConfig
-	transcriptionFailureThreshold uint
-	toneDetectionIssueThreshold uint
-	alertRetentionDays          uint
-	noAudioThresholdMinutes     uint
-	noAudioMultiplier            float64
-	systemHealthAlertsEnabled   bool
+	autoPopulate                      bool
+	audioConversion                   uint
+	branding                          string
+	defaultSystemDelay                uint
+	disableDuplicateDetection         bool
+	duplicateDetectionTimeFrame       uint
+	duplicateTimestampWindow          uint
+	email                             string
+	keypadBeeps                       string
+	maxClients                        uint
+	playbackGoesLive                  bool
+	pruneDays                         uint
+	showListenersCount                bool
+	sortTalkgroups                    bool
+	time12hFormat                     bool
+	radioReferenceEnabled             bool
+	radioReferenceUsername            string
+	radioReferencePassword            string
+	userRegistrationEnabled           bool
+	publicRegistrationEnabled         bool
+	publicRegistrationMode            string
+	emailVerificationRequired         bool
+	stripePaywallEnabled              bool
+	emailServiceEnabled               bool
+	emailServiceApiKey                string
+	emailServiceDomain                string
+	emailServiceTemplateId            string
+	emailProvider                     string
+	emailSendGridAPIKey               string
+	emailMailgunAPIKey                string
+	emailMailgunDomain                string
+	emailMailgunAPIBase               string
+	emailSmtpHost                     string
+	emailSmtpPort                     int
+	emailSmtpUsername                 string
+	emailSmtpPassword                 string
+	emailSmtpUseTLS                   bool
+	emailSmtpSkipVerify               bool
+	emailSmtpFromEmail                string
+	emailSmtpFromName                 string
+	emailLogoFilename                 string
+	emailLogoBorderRadius             string
+	faviconFilename                   string
+	stripePublishableKey              string
+	stripeSecretKey                   string
+	stripeWebhookSecret               string
+	stripeGracePeriodDays             uint
+	stripePriceId                     string
+	baseUrl                           string
+	transcriptionConfig               DefaultTranscriptionConfig
+	transcriptionFailureThreshold     uint
+	toneDetectionIssueThreshold       uint
+	alertRetentionDays                uint
+	noAudioThresholdMinutes           uint
+	noAudioMultiplier                 float64
+	systemHealthAlertsEnabled         bool
 	transcriptionFailureAlertsEnabled bool
-	toneDetectionAlertsEnabled  bool
-	noAudioAlertsEnabled        bool
-	transcriptionFailureTimeWindow uint
-	toneDetectionTimeWindow     uint
-	noAudioTimeWindow           uint
-	noAudioHistoricalDataDays   uint
+	toneDetectionAlertsEnabled        bool
+	noAudioAlertsEnabled              bool
+	transcriptionFailureTimeWindow    uint
+	toneDetectionTimeWindow           uint
+	noAudioTimeWindow                 uint
+	noAudioHistoricalDataDays         uint
 	transcriptionFailureRepeatMinutes uint
 	toneDetectionRepeatMinutes        uint
 	noAudioRepeatMinutes              uint
-	adminLocalhostOnly          bool
-	configSyncEnabled           bool
-	configSyncPath              string
-	reconnectionEnabled         bool
-	reconnectionGracePeriod     uint
-	reconnectionMaxBufferSize   uint
+	adminLocalhostOnly                bool
+	configSyncEnabled                 bool
+	configSyncPath                    string
+	reconnectionEnabled               bool
+	reconnectionGracePeriod           uint
+	reconnectionMaxBufferSize         uint
 }
 
 type DefaultTranscriptionConfig struct {
-	enabled          bool
-	provider         string
-	whisperAPIURL    string
-	whisperAPIKey    string
-	azureKey         string
-	azureRegion      string
-	googleAPIKey     string
+	enabled           bool
+	provider          string
+	whisperAPIURL     string
+	whisperAPIKey     string
+	azureKey          string
+	azureRegion       string
+	googleAPIKey      string
 	googleCredentials string
-	assemblyAIKey    string
-	language         string
-	prompt           string
-	workerPoolSize   int
+	assemblyAIKey     string
+	language          string
+	prompt            string
+	workerPoolSize    int
 }
 
 var defaults = Defaults{
@@ -211,53 +211,53 @@ var defaults = Defaults{
 		stripePriceId:               "",
 		baseUrl:                     "",
 		transcriptionConfig: DefaultTranscriptionConfig{
-			enabled:        false,
-			provider:       "whisper-api", // Default to external Whisper API server
-			whisperAPIURL:  "http://localhost:8000",
-			whisperAPIKey:  "",
-			azureKey:       "",
-			azureRegion:    "eastus",
-			googleAPIKey:   "",
+			enabled:           false,
+			provider:          "whisper-api", // Default to external Whisper API server
+			whisperAPIURL:     "http://localhost:8000",
+			whisperAPIKey:     "",
+			azureKey:          "",
+			azureRegion:       "eastus",
+			googleAPIKey:      "",
 			googleCredentials: "",
-			assemblyAIKey:  "",
-			language:       "en",       // English by default
-			prompt:         "",         // No default prompt
-			workerPoolSize: 3,          // Conservative default
+			assemblyAIKey:     "",
+			language:          "en", // English by default
+			prompt:            "",   // No default prompt
+			workerPoolSize:    3,    // Conservative default
 		},
-		transcriptionFailureThreshold: 10,
-		toneDetectionIssueThreshold: 5,
-		alertRetentionDays: 5,
-	noAudioThresholdMinutes: 30,
-	noAudioMultiplier: 1.5,
-	systemHealthAlertsEnabled: true,
-	transcriptionFailureAlertsEnabled: true,
-	toneDetectionAlertsEnabled: true,
-	noAudioAlertsEnabled: true,
-	transcriptionFailureTimeWindow: 24,
-	toneDetectionTimeWindow: 24,
-		noAudioTimeWindow: 24,
-		noAudioHistoricalDataDays: 7,
+		transcriptionFailureThreshold:     10,
+		toneDetectionIssueThreshold:       5,
+		alertRetentionDays:                5,
+		noAudioThresholdMinutes:           30,
+		noAudioMultiplier:                 1.5,
+		systemHealthAlertsEnabled:         true,
+		transcriptionFailureAlertsEnabled: true,
+		toneDetectionAlertsEnabled:        true,
+		noAudioAlertsEnabled:              true,
+		transcriptionFailureTimeWindow:    24,
+		toneDetectionTimeWindow:           24,
+		noAudioTimeWindow:                 24,
+		noAudioHistoricalDataDays:         7,
 		transcriptionFailureRepeatMinutes: 60,
-		toneDetectionRepeatMinutes: 60,
-		noAudioRepeatMinutes: 30,
-		adminLocalhostOnly: false, // Default to false for backwards compatibility
-		configSyncEnabled:  false,
-		configSyncPath:     "",
-		reconnectionEnabled: true,       // Enable by default
-		reconnectionGracePeriod: 60,     // 60 seconds
-		reconnectionMaxBufferSize: 100,  // 100 calls max
+		toneDetectionRepeatMinutes:        60,
+		noAudioRepeatMinutes:              30,
+		adminLocalhostOnly:                false, // Default to false for backwards compatibility
+		configSyncEnabled:                 false,
+		configSyncPath:                    "",
+		reconnectionEnabled:               true, // Enable by default
+		reconnectionGracePeriod:           60,   // 60 seconds
+		reconnectionMaxBufferSize:         100,  // 100 calls max
 	},
 	systems: []System{
 		{
 			Id:           1,
 			Label:        "Default System",
-		SystemRef:    1,
-		AutoPopulate: true,
-		Blacklists:   "",
-		Delay:        0,
-		Order:        1,
-		Kind:         "",
-	},
+			SystemRef:    1,
+			AutoPopulate: true,
+			Blacklists:   "",
+			Delay:        0,
+			Order:        1,
+			Kind:         "",
+		},
 	},
 	tags: []string{
 		"Emergency",

--- a/server/device_token.go
+++ b/server/device_token.go
@@ -36,8 +36,8 @@ type DeviceToken struct {
 
 type DeviceTokens struct {
 	mutex      sync.RWMutex
-	tokens     map[uint64]*DeviceToken    // by device token ID
-	userTokens map[uint64][]*DeviceToken  // by user ID
+	tokens     map[uint64]*DeviceToken   // by device token ID
+	userTokens map[uint64][]*DeviceToken // by user ID
 	// tokenIndex provides O(1) lookup by FCM token string.
 	// Used to efficiently clean up invalid tokens reported by the relay server
 	// without scanning all users.
@@ -94,7 +94,7 @@ func (dt *DeviceTokens) Load(db *Database) error {
 		if err != nil {
 			continue
 		}
-		
+
 		// Handle nullable fields
 		if fcmToken != nil {
 			token.FCMToken = *fcmToken
@@ -154,7 +154,7 @@ func (dt *DeviceTokens) Add(token *DeviceToken, db *Database) error {
 	if token.PushType != "" {
 		pushType = &token.PushType
 	}
-	
+
 	var tokenId int64
 	err := db.Sql.QueryRow(
 		`INSERT INTO "deviceTokens" ("userId", "token", "fcmToken", "pushType", "platform", "sound", "createdAt", "lastUsed") 
@@ -224,7 +224,7 @@ func (dt *DeviceTokens) Delete(id uint64, db *Database) error {
 	if len(truncatedToken) > 10 {
 		truncatedToken = truncatedToken[:10] + "..."
 	}
-	log.Printf("DeviceTokens.Delete: removing device token ID %d for user %d (token: %s, platform: %s)", 
+	log.Printf("DeviceTokens.Delete: removing device token ID %d for user %d (token: %s, platform: %s)",
 		id, token.UserId, truncatedToken, token.Platform)
 
 	_, err := db.Sql.Exec(`DELETE FROM "deviceTokens" WHERE "deviceTokenId" = $1`, id)
@@ -260,7 +260,7 @@ func (dt *DeviceTokens) GetByUser(userId uint64) []*DeviceToken {
 	if tokens == nil {
 		return []*DeviceToken{} // Return empty slice instead of nil
 	}
-	
+
 	// Return a copy to prevent external modification
 	result := make([]*DeviceToken, len(tokens))
 	copy(result, tokens)
@@ -330,4 +330,3 @@ func (dt *DeviceTokens) RemoveAllLegacyTokensForUser(userId uint64, db *Database
 
 	return nil
 }
-

--- a/server/dirwatch.go
+++ b/server/dirwatch.go
@@ -196,24 +196,24 @@ func (dirwatch *Dirwatch) ingestDefault(p string) error {
 			return err
 		}
 
-	dirwatch.parseMask(call)
+		dirwatch.parseMask(call)
 
-	if dirwatch.SystemId > 0 {
-		call.Meta.SystemId = dirwatch.SystemId
-		// Dirwatch uses Meta.* for labels/refs, but validation expects top-level ids.
-		// Keep both in sync.
-		if dirwatch.SystemId <= uint64(^uint(0)) {
-			call.SystemId = uint(dirwatch.SystemId)
+		if dirwatch.SystemId > 0 {
+			call.Meta.SystemId = dirwatch.SystemId
+			// Dirwatch uses Meta.* for labels/refs, but validation expects top-level ids.
+			// Keep both in sync.
+			if dirwatch.SystemId <= uint64(^uint(0)) {
+				call.SystemId = uint(dirwatch.SystemId)
+			}
 		}
-	}
 
-	if dirwatch.TalkgroupId > 0 {
-		call.Meta.TalkgroupId = dirwatch.TalkgroupId
-		// Keep top-level talkgroup id in sync for validation.
-		if dirwatch.TalkgroupId <= uint64(^uint(0)) {
-			call.TalkgroupId = uint(dirwatch.TalkgroupId)
+		if dirwatch.TalkgroupId > 0 {
+			call.Meta.TalkgroupId = dirwatch.TalkgroupId
+			// Keep top-level talkgroup id in sync for validation.
+			if dirwatch.TalkgroupId <= uint64(^uint(0)) {
+				call.TalkgroupId = uint(dirwatch.TalkgroupId)
+			}
 		}
-	}
 
 		if ok, err := call.IsValid(); ok {
 			dirwatch.controller.Ingest <- call

--- a/server/email.go
+++ b/server/email.go
@@ -68,7 +68,7 @@ func generateMessageID(domain string) string {
 	randomBytes := make([]byte, 16)
 	rand.Read(randomBytes)
 	randomHex := hex.EncodeToString(randomBytes)
-	
+
 	// Format: <timestamp.random@domain>
 	timestamp := time.Now().Unix()
 	return fmt.Sprintf("<%d.%s@%s>", timestamp, randomHex, domain)
@@ -99,13 +99,13 @@ func htmlToPlainText(htmlContent string) string {
 	// Remove HTML tags
 	re := regexp.MustCompile(`<[^>]*>`)
 	text := re.ReplaceAllString(htmlContent, "")
-	
+
 	// Decode HTML entities
 	text = html.UnescapeString(text)
-	
+
 	// Remove emojis
 	text = removeEmojis(text)
-	
+
 	// Clean up whitespace
 	text = strings.TrimSpace(text)
 	lines := strings.Split(text, "\n")
@@ -116,7 +116,7 @@ func htmlToPlainText(htmlContent string) string {
 			cleanedLines = append(cleanedLines, trimmed)
 		}
 	}
-	
+
 	return strings.Join(cleanedLines, "\n\n")
 }
 
@@ -127,19 +127,19 @@ func buildEmailMessage(fromName, fromEmail, toEmail, subject, htmlBody string) s
 	htmlBody = removeEmojisFromHTML(htmlBody)
 	// Extract domain for HELO and Message-ID
 	domain := extractDomainFromEmail(fromEmail)
-	
+
 	// Generate unique Message-ID
 	messageID := generateMessageID(domain)
-	
+
 	// Convert HTML to plain text
 	plainText := htmlToPlainText(htmlBody)
-	
+
 	// Create multipart boundary
 	boundary := fmt.Sprintf("----=_Part_%d_%s", time.Now().Unix(), strings.ReplaceAll(messageID, "@", "_at_"))
-	
+
 	// Build message with proper headers
 	var message strings.Builder
-	
+
 	// Standard headers
 	message.WriteString(fmt.Sprintf("From: %s <%s>\r\n", fromName, fromEmail))
 	message.WriteString(fmt.Sprintf("To: %s\r\n", toEmail))
@@ -151,7 +151,7 @@ func buildEmailMessage(fromName, fromEmail, toEmail, subject, htmlBody string) s
 	message.WriteString("MIME-Version: 1.0\r\n")
 	message.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n", boundary))
 	message.WriteString("\r\n")
-	
+
 	// Plain text part
 	message.WriteString(fmt.Sprintf("--%s\r\n", boundary))
 	message.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
@@ -159,7 +159,7 @@ func buildEmailMessage(fromName, fromEmail, toEmail, subject, htmlBody string) s
 	message.WriteString("\r\n")
 	message.WriteString(plainText)
 	message.WriteString("\r\n\r\n")
-	
+
 	// HTML part
 	message.WriteString(fmt.Sprintf("--%s\r\n", boundary))
 	message.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
@@ -167,10 +167,10 @@ func buildEmailMessage(fromName, fromEmail, toEmail, subject, htmlBody string) s
 	message.WriteString("\r\n")
 	message.WriteString(htmlBody)
 	message.WriteString("\r\n\r\n")
-	
+
 	// End boundary
 	message.WriteString(fmt.Sprintf("--%s--\r\n", boundary))
-	
+
 	return message.String()
 }
 
@@ -179,7 +179,7 @@ func (es *EmailService) sendSendGridEmail(fromName, fromEmail, toEmail, subject,
 	// Remove emojis from subject and body (already done in sendEmail, but ensure it here too)
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	apiKey := es.Controller.Options.EmailSendGridAPIKey
 	if apiKey == "" {
 		return fmt.Errorf("SendGrid API key is not configured")
@@ -253,7 +253,7 @@ func (es *EmailService) sendMailgunEmail(fromName, fromEmail, toEmail, subject, 
 	// Remove emojis from subject and body (already done in sendEmail, but ensure it here too)
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	apiKey := es.Controller.Options.EmailMailgunAPIKey
 	domain := es.Controller.Options.EmailMailgunDomain
 	apiBase := es.Controller.Options.EmailMailgunAPIBase
@@ -342,7 +342,7 @@ func (es *EmailService) sendSMTPEmail(fromName, fromEmail, toEmail, subject, htm
 
 	// Attempt to send the email
 	var err error
-	
+
 	// If using TLS on port 465 (implicit TLS/SSL)
 	if useTLS && port == 465 {
 		// Use TLS connection from the start (implicit TLS)
@@ -464,7 +464,7 @@ func (es *EmailService) sendEmail(fromName, fromEmail, toEmail, subject, htmlBod
 	// Remove emojis from subject and body for all emails
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	provider := es.Controller.Options.EmailProvider
 	if provider == "" {
 		provider = "sendgrid" // Default to SendGrid
@@ -488,7 +488,7 @@ func getVerificationEmailHTML(userEmail, verificationURL, branding, logoURL, bor
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -716,7 +716,7 @@ func getEmailChangeVerificationHTML(newEmail, verificationURL, branding, logoURL
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -1060,7 +1060,7 @@ func (es *EmailService) SendVerificationEmail(user *User) error {
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -1152,7 +1152,7 @@ func (es *EmailService) SendSignupVerificationEmail(email, verificationCode stri
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -1167,7 +1167,7 @@ func getSignupVerificationEmailHTML(email, verificationCode, branding, logoURL, 
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -1291,7 +1291,7 @@ func getPasswordResetEmailHTML(resetCode, branding, logoURL, borderRadius string
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -1557,7 +1557,7 @@ func (es *EmailService) SendPasswordResetEmail(user *User, resetCode string) err
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -1648,7 +1648,7 @@ func (es *EmailService) SendEmailChangeVerificationEmail(user *User, verificatio
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -1748,7 +1748,7 @@ func (es *EmailService) SendNewEmailVerificationEmail(newEmail, verificationToke
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -1763,7 +1763,7 @@ func getEmailChangeVerificationCodeHTML(verificationCode, branding, logoURL stri
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -1961,7 +1961,7 @@ func getPasswordChangeVerificationEmailHTML(verificationCode, branding, logoURL 
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -2230,7 +2230,7 @@ func (es *EmailService) SendPasswordChangeVerificationEmail(user *User, verifica
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -2314,7 +2314,7 @@ func (es *EmailService) SendInvitationEmail(email, code, invitationLink, groupNa
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -2329,7 +2329,7 @@ func getInvitationEmailHTML(email, code, invitationLink, groupName, branding, lo
 	if branding == "" {
 		branding = "ThinLine Radio"
 	}
-	
+
 	htmlTemplate := `<!DOCTYPE html>
 <html>
 <head>
@@ -2437,21 +2437,21 @@ func getInvitationEmailHTML(email, code, invitationLink, groupName, branding, lo
 
 	var buf bytes.Buffer
 	data := struct {
-		Email         string
-		Code          string
+		Email          string
+		Code           string
 		InvitationLink string
-		GroupName     string
-		Branding      string
-		LogoURL       string
-		BorderRadius  string
+		GroupName      string
+		Branding       string
+		LogoURL        string
+		BorderRadius   string
 	}{
-		Email:         email,
-		Code:          code,
+		Email:          email,
+		Code:           code,
 		InvitationLink: invitationLink,
-		GroupName:     groupName,
-		Branding:      branding,
-		LogoURL:       logoURL,
-		BorderRadius:  borderRadius,
+		GroupName:      groupName,
+		Branding:       branding,
+		LogoURL:        logoURL,
+		BorderRadius:   borderRadius,
 	}
 
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -2542,7 +2542,7 @@ func (es *EmailService) SendUserGroupChangeEmail(user *User, newGroup *UserGroup
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -2627,7 +2627,7 @@ func (es *EmailService) SendUserMovedFromGroupEmail(admin *User, movedUser *User
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -2782,22 +2782,22 @@ func getUserGroupChangeEmailHTML(user *User, newGroup *UserGroup, oldGroup *User
 		userName = extractNameFromEmail(user.Email)
 	}
 	data := struct {
-		Branding          string
-		LogoURL           string
-		BorderRadius      string
-		UserName          string
-		OldGroupName      string
-		NewGroupName      string
-		BillingRequired   bool
+		Branding           string
+		LogoURL            string
+		BorderRadius       string
+		UserName           string
+		OldGroupName       string
+		NewGroupName       string
+		BillingRequired    bool
 		GracePeriodApplied bool
 	}{
-		Branding:          branding,
-		LogoURL:           logoURL,
-		BorderRadius:      borderRadius,
-		UserName:          userName,
-		OldGroupName:      oldGroupName,
-		NewGroupName:      newGroupName,
-		BillingRequired:   billingRequired,
+		Branding:           branding,
+		LogoURL:            logoURL,
+		BorderRadius:       borderRadius,
+		UserName:           userName,
+		OldGroupName:       oldGroupName,
+		NewGroupName:       newGroupName,
+		BillingRequired:    billingRequired,
 		GracePeriodApplied: gracePeriodApplied,
 	}
 
@@ -2939,21 +2939,21 @@ func getUserMovedFromGroupEmailHTML(admin *User, movedUser *User, oldGroup *User
 		movedUserName = movedUser.Email
 	}
 	data := struct {
-		Branding      string
-		LogoURL       string
-		BorderRadius  string
+		Branding       string
+		LogoURL        string
+		BorderRadius   string
 		MovedUserEmail string
-		MovedUserName string
-		OldGroupName  string
-		NewGroupName  string
+		MovedUserName  string
+		OldGroupName   string
+		NewGroupName   string
 	}{
-		Branding:      branding,
-		LogoURL:       logoURL,
-		BorderRadius:  borderRadius,
+		Branding:       branding,
+		LogoURL:        logoURL,
+		BorderRadius:   borderRadius,
 		MovedUserEmail: movedUser.Email,
-		MovedUserName: movedUserName,
-		OldGroupName:  oldGroupName,
-		NewGroupName:  newGroupName,
+		MovedUserName:  movedUserName,
+		OldGroupName:   oldGroupName,
+		NewGroupName:   newGroupName,
 	}
 
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -3055,7 +3055,7 @@ func (es *EmailService) SendTransferRequestEmail(admin *User, transferReq *Trans
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err
@@ -3329,7 +3329,7 @@ func (es *EmailService) SendTestEmail(toEmail string) error {
 	// Remove emojis from subject and body
 	subject = removeEmojis(subject)
 	htmlBody = removeEmojisFromHTML(htmlBody)
-	
+
 	// Send email using provider routing
 	if err := es.sendEmail(fromName, fromEmail, toEmail, subject, htmlBody); err != nil {
 		return err

--- a/server/email_templates.go
+++ b/server/email_templates.go
@@ -23,9 +23,9 @@ import (
 
 // EmailTemplateData holds the data for email templates
 type EmailTemplateData struct {
-	UserEmail        string
-	VerificationURL  string
-	BaseURL          string
+	UserEmail       string
+	VerificationURL string
+	BaseURL         string
 }
 
 // EmailTemplates manages email templates
@@ -37,21 +37,21 @@ type EmailTemplates struct {
 // NewEmailTemplates creates a new EmailTemplates instance
 func NewEmailTemplates() (*EmailTemplates, error) {
 	et := &EmailTemplates{}
-	
+
 	// Load HTML template
 	htmlTmpl, err := template.ParseFiles("templates/email_verification.html")
 	if err != nil {
 		return nil, err
 	}
 	et.verificationHTML = htmlTmpl
-	
+
 	// Load text template
 	textTmpl, err := texttemplate.ParseFiles("templates/email_verification.txt")
 	if err != nil {
 		return nil, err
 	}
 	et.verificationText = textTmpl
-	
+
 	return et, nil
 }
 
@@ -63,14 +63,14 @@ func (et *EmailTemplates) GenerateVerificationEmail(data EmailTemplateData) (htm
 		return "", "", err
 	}
 	htmlContent = htmlBuf.String()
-	
+
 	// Generate text content
 	var textBuf bytes.Buffer
 	if err := et.verificationText.Execute(&textBuf, data); err != nil {
 		return "", "", err
 	}
 	textContent = textBuf.String()
-	
+
 	return htmlContent, textContent, nil
 }
 

--- a/server/hallucination_detector.go
+++ b/server/hallucination_detector.go
@@ -245,7 +245,7 @@ func (hd *HallucinationDetector) autoAddPattern(sh *SuspectedHallucination) {
 		return
 	}
 
-	hd.controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("auto-added hallucination pattern: %q (rejected: %d, systems: %d, score: %.1f)", 
+	hd.controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("auto-added hallucination pattern: %q (rejected: %d, systems: %d, score: %.1f)",
 		sh.Phrase, sh.RejectedCount, len(sh.SystemIds), sh.ConfidenceScore))
 }
 
@@ -289,7 +289,6 @@ func (hd *HallucinationDetector) getOrCreatePhrase(phrase string, systemId uint6
 // getPhrase retrieves a phrase from the database
 func (hd *HallucinationDetector) getPhrase(phrase string) (*SuspectedHallucination, error) {
 	query := `SELECT "id", "phrase", "rejectedCount", "acceptedCount", "firstSeenAt", "lastSeenAt", "systemIds", "status", "autoAdded", "createdAt", "updatedAt" FROM "suspectedHallucinations" WHERE "phrase" = $1`
-
 
 	var sh SuspectedHallucination
 	var systemIdsJson string
@@ -392,14 +391,14 @@ func (hd *HallucinationDetector) ApproveHallucination(id uint64) error {
 
 	// Add to hallucination patterns
 	patterns := hd.controller.Options.TranscriptionConfig.HallucinationPatterns
-	
+
 	// Check if already exists
 	for _, p := range patterns {
 		if strings.EqualFold(p, sh.Phrase) {
 			return fmt.Errorf("pattern already exists")
 		}
 	}
-	
+
 	patterns = append(patterns, sh.Phrase)
 	hd.controller.Options.TranscriptionConfig.HallucinationPatterns = patterns
 
@@ -432,4 +431,3 @@ func (hd *HallucinationDetector) RejectHallucination(id uint64) error {
 	_, err := hd.controller.Database.Sql.Exec(query)
 	return err
 }
-

--- a/server/keyword_matcher.go
+++ b/server/keyword_matcher.go
@@ -36,7 +36,7 @@ type KeywordMatcher struct {
 
 	// Compiled regex cache: keyed by the uppercased keyword so the same
 	// pattern is only compiled once for the lifetime of the process.
-	mu      sync.RWMutex
+	mu       sync.RWMutex
 	compiled map[string]*regexp.Regexp
 }
 
@@ -74,22 +74,22 @@ func (matcher *KeywordMatcher) getCompiledPattern(keywordUpper string) (*regexp.
 // Transcript should already be in ALL CAPS
 func (matcher *KeywordMatcher) MatchKeywords(transcript string, keywords []string) []KeywordMatch {
 	matches := []KeywordMatch{}
-	
+
 	if transcript == "" || len(keywords) == 0 {
 		return matches
 	}
-	
+
 	// Ensure transcript is uppercase
 	transcriptUpper := strings.ToUpper(transcript)
-	
+
 	for _, keyword := range keywords {
 		if keyword == "" {
 			continue
 		}
-		
+
 		// Convert keyword to uppercase for case-insensitive matching
 		keywordUpper := strings.ToUpper(strings.TrimSpace(keyword))
-		
+
 		// Look up (or compile) the cached regex for this keyword.
 		re, err := matcher.getCompiledPattern(keywordUpper)
 		if err != nil {
@@ -101,34 +101,34 @@ func (matcher *KeywordMatcher) MatchKeywords(transcript string, keywords []strin
 				if index == -1 {
 					break
 				}
-				
+
 				actualPos := pos + index
-				
+
 				// Check if it's a whole word match
 				if matcher.isWholeWord(transcriptUpper, actualPos, len(keywordUpper)) {
 					// Extract context (surrounding text)
 					context := matcher.extractContext(transcript, actualPos, len(keywordUpper))
-					
+
 					matches = append(matches, KeywordMatch{
 						Keyword:  keyword, // Store original keyword (not uppercase)
 						Context:  context,
 						Position: actualPos,
 					})
 				}
-				
+
 				pos = actualPos + 1
 			}
 			continue
 		}
-		
+
 		// Find all whole-word matches using regex
 		allMatches := re.FindAllStringIndex(transcriptUpper, -1)
 		for _, match := range allMatches {
 			actualPos := match[0]
-			
+
 			// Extract context (surrounding text)
 			context := matcher.extractContext(transcript, actualPos, len(keywordUpper))
-			
+
 			matches = append(matches, KeywordMatch{
 				Keyword:  keyword, // Store original keyword (not uppercase)
 				Context:  context,
@@ -136,7 +136,7 @@ func (matcher *KeywordMatcher) MatchKeywords(transcript string, keywords []strin
 			})
 		}
 	}
-	
+
 	return matches
 }
 
@@ -150,7 +150,7 @@ func (matcher *KeywordMatcher) isWholeWord(text string, pos int, length int) boo
 			return false
 		}
 	}
-	
+
 	// Check character after the match
 	if pos+length < len(text) {
 		charAfter := text[pos+length]
@@ -158,7 +158,7 @@ func (matcher *KeywordMatcher) isWholeWord(text string, pos int, length int) boo
 			return false
 		}
 	}
-	
+
 	return true
 }
 
@@ -168,14 +168,14 @@ func (matcher *KeywordMatcher) extractContext(transcript string, position int, k
 	if start < 0 {
 		start = 0
 	}
-	
+
 	end := position + keywordLength + matcher.contextChars
 	if end > len(transcript) {
 		end = len(transcript)
 	}
-	
+
 	context := transcript[start:end]
-	
+
 	// Add ellipsis if we truncated
 	if start > 0 {
 		context = "..." + context
@@ -183,7 +183,6 @@ func (matcher *KeywordMatcher) extractContext(transcript string, position int, k
 	if end < len(transcript) {
 		context = context + "..."
 	}
-	
+
 	return context
 }
-

--- a/server/options.go
+++ b/server/options.go
@@ -118,10 +118,10 @@ type Options struct {
 	AudioEncryptionEnabled bool `json:"audioEncryptionEnabled"`
 	// Download rate limiting — applied per WebSocket connection.
 	// Set MaxDownloadsPerWindow to 0 to disable.
-	MaxDownloadsPerWindow uint `json:"maxDownloadsPerWindow"` // max download requests in the window
-	DownloadWindowMinutes uint `json:"downloadWindowMinutes"` // rolling window size in minutes (1–60)
-	RadioReferenceAPIKey              string `json:"radioReferenceAPIKey"`
-	AdminLocalhostOnly                bool   `json:"adminLocalhostOnly"`
+	MaxDownloadsPerWindow uint   `json:"maxDownloadsPerWindow"` // max download requests in the window
+	DownloadWindowMinutes uint   `json:"downloadWindowMinutes"` // rolling window size in minutes (1–60)
+	RadioReferenceAPIKey  string `json:"radioReferenceAPIKey"`
+	AdminLocalhostOnly    bool   `json:"adminLocalhostOnly"`
 	// When true, the traditional admin password login form is disabled. Admin access is only
 	// possible via system admin user SSO or Central Management one-click login.
 	// Guard: the server refuses to set this if no SystemAdmin user exists.
@@ -1517,35 +1517,35 @@ func (options *Options) Read(db *Database) error {
 					options.RelayServerURL = v
 				}
 			}
-	case "relayServerAPIKey":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case string:
-				options.RelayServerAPIKey = v
+		case "relayServerAPIKey":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case string:
+					options.RelayServerAPIKey = v
+				}
 			}
-		}
-	case "audioEncryptionEnabled":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case bool:
-				options.AudioEncryptionEnabled = v
+		case "audioEncryptionEnabled":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case bool:
+					options.AudioEncryptionEnabled = v
+				}
 			}
-		}
-	case "maxDownloadsPerWindow":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case float64:
-				options.MaxDownloadsPerWindow = uint(v)
+		case "maxDownloadsPerWindow":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case float64:
+					options.MaxDownloadsPerWindow = uint(v)
+				}
 			}
-		}
-	case "downloadWindowMinutes":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case float64:
-				options.DownloadWindowMinutes = uint(v)
+		case "downloadWindowMinutes":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case float64:
+					options.DownloadWindowMinutes = uint(v)
+				}
 			}
-		}
-	case "hydraAPIKey":
+		case "hydraAPIKey":
 			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
 				switch v := f.(type) {
 				case string:

--- a/server/radioreference.go
+++ b/server/radioreference.go
@@ -88,9 +88,9 @@ type RadioReferenceSite struct {
 	Name        string    `xml:"name" json:"name"` // This will store siteDescr
 	Latitude    float64   `xml:"latitude" json:"latitude"`
 	Longitude   float64   `xml:"longitude" json:"longitude"`
-	CountyID    int       `xml:"countyId" json:"countyId"`     // This will store siteCtid
-	CountyName  string    `xml:"countyName" json:"countyName"` // This will store countyName
-	RFSS        int       `xml:"rfss" json:"rfss"`             // This will store rfss
+	CountyID    int       `xml:"countyId" json:"countyId"`       // This will store siteCtid
+	CountyName  string    `xml:"countyName" json:"countyName"`   // This will store countyName
+	RFSS        int       `xml:"rfss" json:"rfss"`               // This will store rfss
 	Frequencies []float64 `xml:"frequencies" json:"frequencies"` // Site frequencies
 }
 
@@ -1200,7 +1200,7 @@ func parseSiteList(bodyContent []byte) ([]RadioReferenceSite, error) {
 		if siteFreqsNode != nil {
 			freqItems := xmlquery.Find(siteFreqsNode, "item")
 			log.Printf("Site %s: Found %d frequency items", site.Name, len(freqItems))
-			
+
 			for _, freqItem := range freqItems {
 				// Each item contains lcn, freq, use, colorCode, ch_id
 				if freqValueNode := xmlquery.FindOne(freqItem, "freq"); freqValueNode != nil {

--- a/server/rate_limiter.go
+++ b/server/rate_limiter.go
@@ -56,8 +56,8 @@ type LoginAttemptTracker struct {
 
 type loginAttemptEntry struct {
 	failedAttempts int
-	blockedUntil    *time.Time
-	lastAttempt     time.Time
+	blockedUntil   *time.Time
+	lastAttempt    time.Time
 }
 
 // NewRateLimiter creates a new rate limiter
@@ -160,7 +160,7 @@ func (lat *LoginAttemptTracker) RecordFailedAttempt(ip string) {
 	if !exists {
 		entry = &loginAttemptEntry{
 			failedAttempts: 0,
-			lastAttempt:     now,
+			lastAttempt:    now,
 		}
 		lat.attempts[ip] = entry
 	}
@@ -257,12 +257,12 @@ func getRemoteAddr(r *http.Request) string {
 		}
 		return strings.TrimSpace(forwarded)
 	}
-	
+
 	// Check X-Real-IP header (another common reverse proxy header)
 	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
 		return strings.TrimSpace(realIP)
 	}
-	
+
 	// Fall back to RemoteAddr
 	ip := r.RemoteAddr
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
@@ -302,16 +302,16 @@ func LoginAttemptMiddleware(tracker *LoginAttemptTracker) func(http.Handler) htt
 			if tracker.IsBlocked(ip) {
 				remaining := tracker.GetRemainingBlockTime(ip)
 				remainingSeconds := int(remaining.Seconds())
-				
+
 				// Return JSON error with redirect URL for client to handle
 				w.Header().Set("Content-Type", "application/json")
 				w.Header().Set("Retry-After", fmt.Sprintf("%.0f", remaining.Seconds()))
 				w.WriteHeader(http.StatusTooManyRequests)
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"error":       "Too many failed login attempts. IP address temporarily blocked.",
-					"blocked":     true,
-					"redirectTo":  fmt.Sprintf("/login-blocked?seconds=%d", remainingSeconds),
-					"retryAfter":  remainingSeconds,
+					"error":        "Too many failed login attempts. IP address temporarily blocked.",
+					"blocked":      true,
+					"redirectTo":   fmt.Sprintf("/login-blocked?seconds=%d", remainingSeconds),
+					"retryAfter":   remainingSeconds,
 					"blockedUntil": remaining.String(),
 				})
 				return
@@ -321,4 +321,3 @@ func LoginAttemptMiddleware(tracker *LoginAttemptTracker) func(http.Handler) htt
 		})
 	}
 }
-

--- a/server/reconnection.go
+++ b/server/reconnection.go
@@ -33,12 +33,12 @@ type DisconnectedClientState struct {
 
 // ReconnectionManager manages reconnection states for disconnected clients
 type ReconnectionManager struct {
-	States       map[string]*DisconnectedClientState // Key: User ID or PIN
-	mutex        sync.RWMutex
-	HoldDuration time.Duration // How long to hold buffers
-	MaxBufferSize int          // Maximum calls to buffer per user
-	Enabled      bool
-	controller   *Controller
+	States        map[string]*DisconnectedClientState // Key: User ID or PIN
+	mutex         sync.RWMutex
+	HoldDuration  time.Duration // How long to hold buffers
+	MaxBufferSize int           // Maximum calls to buffer per user
+	Enabled       bool
+	controller    *Controller
 }
 
 // NewReconnectionManager creates a new reconnection manager
@@ -63,12 +63,12 @@ func (rm *ReconnectionManager) SaveDisconnectedState(client *Client) {
 	defer rm.mutex.Unlock()
 
 	userKey := rm.getUserKey(client.User)
-	
+
 	// Create a deep copy of the livefeed matrix to preserve filter state
 	livefeedCopy := &Livefeed{
 		Matrix: make(map[uint]map[uint]bool),
 	}
-	
+
 	// Copy the matrix
 	for sysId, talkgroups := range client.Livefeed.Matrix {
 		livefeedCopy.Matrix[sysId] = make(map[uint]bool)
@@ -98,7 +98,7 @@ func (rm *ReconnectionManager) BufferCallForDisconnected(call *Call) {
 	defer rm.mutex.Unlock()
 
 	now := time.Now()
-	
+
 	for _, state := range rm.States {
 		// Skip if grace period expired
 		if now.Sub(state.LastSeen) > rm.HoldDuration {
@@ -134,10 +134,10 @@ func (rm *ReconnectionManager) RestoreClientState(client *Client) bool {
 	}
 
 	rm.mutex.Lock()
-	
+
 	userKey := rm.getUserKey(client.User)
 	state, exists := rm.States[userKey]
-	
+
 	if !exists {
 		rm.mutex.Unlock()
 		return false
@@ -155,7 +155,7 @@ func (rm *ReconnectionManager) RestoreClientState(client *Client) bool {
 	missedCalls := state.MissedCalls
 	missedCount := len(missedCalls)
 	disconnectDuration := time.Since(state.LastSeen)
-	
+
 	// Restore livefeed state
 	client.Livefeed = state.Livefeed
 
@@ -164,7 +164,7 @@ func (rm *ReconnectionManager) RestoreClientState(client *Client) bool {
 	rm.mutex.Unlock()
 
 	if missedCount == 0 {
-		log.Printf("[ReconnectionManager] User %s (PIN: %s) reconnected after %.1fs - no missed calls", 
+		log.Printf("[ReconnectionManager] User %s (PIN: %s) reconnected after %.1fs - no missed calls",
 			userKey, client.User.Pin, disconnectDuration.Seconds())
 		return true
 	}
@@ -174,7 +174,7 @@ func (rm *ReconnectionManager) RestoreClientState(client *Client) bool {
 		successCount := 0
 		for _, call := range missedCalls {
 			msg := &Message{Command: MessageCommandCall, Payload: call}
-			
+
 			select {
 			case client.Send <- msg:
 				successCount++
@@ -182,13 +182,13 @@ func (rm *ReconnectionManager) RestoreClientState(client *Client) bool {
 				time.Sleep(5 * time.Millisecond)
 			default:
 				// Channel full, stop trying to avoid blocking
-				log.Printf("[ReconnectionManager] Channel full while sending buffered calls to user %s (sent %d/%d)", 
+				log.Printf("[ReconnectionManager] Channel full while sending buffered calls to user %s (sent %d/%d)",
 					userKey, successCount, missedCount)
 				return
 			}
 		}
-		
-		log.Printf("[ReconnectionManager] Successfully sent %d buffered calls to user %s (PIN: %s) after %.1fs disconnect", 
+
+		log.Printf("[ReconnectionManager] Successfully sent %d buffered calls to user %s (PIN: %s) after %.1fs disconnect",
 			successCount, userKey, client.User.Pin, disconnectDuration.Seconds())
 	}()
 
@@ -205,7 +205,7 @@ func (rm *ReconnectionManager) StartCleanup() {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
-		log.Printf("[ReconnectionManager] Cleanup routine started (grace period: %v, max buffer: %d)", 
+		log.Printf("[ReconnectionManager] Cleanup routine started (grace period: %v, max buffer: %d)",
 			rm.HoldDuration, rm.MaxBufferSize)
 
 		for range ticker.C {
@@ -221,11 +221,11 @@ func (rm *ReconnectionManager) StartCleanup() {
 					expiredCount++
 				}
 			}
-			
+
 			rm.mutex.Unlock()
 
 			if expiredCount > 0 {
-				log.Printf("[ReconnectionManager] Cleaned up %d expired states (%d calls dropped)", 
+				log.Printf("[ReconnectionManager] Cleaned up %d expired states (%d calls dropped)",
 					expiredCount, totalDroppedCalls)
 			}
 		}
@@ -258,4 +258,3 @@ func (rm *ReconnectionManager) getUserKey(user *User) string {
 	}
 	return fmt.Sprintf("pin:%s", user.Pin)
 }
-

--- a/server/registration_code.go
+++ b/server/registration_code.go
@@ -59,14 +59,14 @@ func NewRegistrationCodes() *RegistrationCodes {
 func generateRegistrationCode() (string, error) {
 	// Generate a 12-character code with alphanumeric and at least one special character
 	buf := make([]byte, registrationCodeLength)
-	
+
 	// First, ensure we have at least one special character
 	specialBuf := make([]byte, 1)
 	if _, err := rand.Read(specialBuf); err != nil {
 		return "", err
 	}
 	specialPos := int(specialBuf[0]) % registrationCodeLength
-	
+
 	// Fill the rest with alphanumeric or special characters
 	allChars := alphanumericChars + specialChars
 	for i := 0; i < registrationCodeLength; i++ {
@@ -86,9 +86,9 @@ func generateRegistrationCode() (string, error) {
 			buf[i] = allChars[int(charBuf[0])%len(allChars)]
 		}
 	}
-	
+
 	code := string(buf)
-	
+
 	// Verify we have at least one special character (should always be true, but double-check)
 	hasSpecial := false
 	for _, char := range code {
@@ -97,7 +97,7 @@ func generateRegistrationCode() (string, error) {
 			break
 		}
 	}
-	
+
 	if !hasSpecial {
 		// If somehow we don't have a special char, replace a random position
 		replacePos := int(buf[0]) % registrationCodeLength
@@ -107,7 +107,7 @@ func generateRegistrationCode() (string, error) {
 		}
 		code = code[:replacePos] + string(specialChars[int(specialBuf[0])%len(specialChars)]) + code[replacePos+1:]
 	}
-	
+
 	return code, nil
 }
 
@@ -192,7 +192,7 @@ func (rcs *RegistrationCodes) Load(db *Database) error {
 		} else {
 			code.CreatedBy = 0 // System admin created
 		}
-		
+
 		if expiresAt.Valid {
 			code.ExpiresAt = expiresAt.Int64
 		}
@@ -266,14 +266,14 @@ func (rcs *RegistrationCodes) Use(code string, db *Database) error {
 func (rcs *RegistrationCodes) Add(code *RegistrationCode, db *Database) error {
 	var id int64
 	var createdBy interface{}
-	
+
 	// Use NULL if createdBy is 0 (system admin), otherwise use the user ID
 	if code.CreatedBy == 0 {
 		createdBy = nil
 	} else {
 		createdBy = code.CreatedBy
 	}
-	
+
 	err := db.Sql.QueryRow(
 		`INSERT INTO "registrationCodes" ("code", "label", "userGroupId", "createdBy", "expiresAt", "maxUses", "currentUses", "isOneTime", "isActive", "createdAt") 
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING "registrationCodeId"`,
@@ -327,4 +327,3 @@ func (rcs *RegistrationCodes) GetAll() []*RegistrationCode {
 	}
 	return codes
 }
-

--- a/server/site.go
+++ b/server/site.go
@@ -29,8 +29,8 @@ type Site struct {
 	Id          uint64
 	Label       string
 	Order       uint
-	SiteRef     string    // Site ID as string to preserve leading zeros (e.g., "001", "021")
-	RFSS        uint      // Radio Frequency Sub-System ID
+	SiteRef     string // Site ID as string to preserve leading zeros (e.g., "001", "021")
+	RFSS        uint   // Radio Frequency Sub-System ID
 	SystemId    uint64
 	Frequencies []float64 // MHz frequencies for this site
 }
@@ -192,7 +192,7 @@ func (sites *Sites) GetSiteByFrequency(frequency uint) (site *Site, ok bool) {
 
 	// Convert frequency from Hz to MHz for comparison
 	freqMHz := float64(frequency) / 1e6
-	
+
 	// Use a tolerance of 0.01 MHz (10 kHz) for matching
 	tolerance := 0.01
 

--- a/server/system.go
+++ b/server/system.go
@@ -38,11 +38,11 @@ type System struct {
 	SystemRef               uint
 	Talkgroups              *Talkgroups
 	Units                   *Units
-	NoAudioAlertsEnabled    bool    // Enable no-audio alerts for this system
-	NoAudioThresholdMinutes uint    // Minutes without audio before alerting
-	AlertsEnabled           bool    // Admin toggle: false suppresses all alerts & transcription for this system
+	NoAudioAlertsEnabled    bool // Enable no-audio alerts for this system
+	NoAudioThresholdMinutes uint // Minutes without audio before alerting
+	AlertsEnabled           bool // Admin toggle: false suppresses all alerts & transcription for this system
 	// When true (default), talkgroups created by auto-populate get alertsEnabled true; when false, they are created with alerts off.
-	AutoPopulateAlertsEnabled bool `json:"autoPopulateAlertsEnabled"`
+	AutoPopulateAlertsEnabled bool   `json:"autoPopulateAlertsEnabled"`
 	TranscriptionPrompt       string // Custom Whisper/AssemblyAI prompt; overrides the global prompt when non-empty
 }
 
@@ -388,46 +388,46 @@ func (systems *Systems) GetScopedSystems(client *Client, groups *Groups, tags *T
 						continue
 					}
 
-				system, ok := systems.GetSystemByRef(systemId)
-				if !ok {
-					continue
-				}
-
-				// Check group access first - if group doesn't allow this system, skip it
-				if !isSystemAllowed(system.SystemRef) {
-					continue
-				}
-
-				switch v := mTalkgroups.(type) {
-				case string:
-					if mTalkgroups == "*" {
-						// User allows all talkgroups, but filter by group restrictions
-						filteredSystem := filterTalkgroupsByGroup(system)
-						rawSystems = append(rawSystems, *filteredSystem)
+					system, ok := systems.GetSystemByRef(systemId)
+					if !ok {
 						continue
 					}
 
-				case []any:
-					rawSystem := *system
-					rawSystem.Talkgroups = NewTalkgroups()
-					for _, fTalkgroupId := range v {
-						switch v := fTalkgroupId.(type) {
-						case float64:
-							rawTalkgroup, ok := system.Talkgroups.GetTalkgroupByRef(uint(v))
-							if !ok {
-								continue
-							}
-							// Check group access for this talkgroup
-							if userGroup != nil && !userGroup.HasTalkgroupAccess(uint64(system.SystemRef), rawTalkgroup.TalkgroupRef) {
-								continue
-							}
-							rawSystem.Talkgroups.List = append(rawSystem.Talkgroups.List, rawTalkgroup)
-						default:
+					// Check group access first - if group doesn't allow this system, skip it
+					if !isSystemAllowed(system.SystemRef) {
+						continue
+					}
+
+					switch v := mTalkgroups.(type) {
+					case string:
+						if mTalkgroups == "*" {
+							// User allows all talkgroups, but filter by group restrictions
+							filteredSystem := filterTalkgroupsByGroup(system)
+							rawSystems = append(rawSystems, *filteredSystem)
 							continue
 						}
+
+					case []any:
+						rawSystem := *system
+						rawSystem.Talkgroups = NewTalkgroups()
+						for _, fTalkgroupId := range v {
+							switch v := fTalkgroupId.(type) {
+							case float64:
+								rawTalkgroup, ok := system.Talkgroups.GetTalkgroupByRef(uint(v))
+								if !ok {
+									continue
+								}
+								// Check group access for this talkgroup
+								if userGroup != nil && !userGroup.HasTalkgroupAccess(uint64(system.SystemRef), rawTalkgroup.TalkgroupRef) {
+									continue
+								}
+								rawSystem.Talkgroups.List = append(rawSystem.Talkgroups.List, rawTalkgroup)
+							default:
+								continue
+							}
+						}
+						rawSystems = append(rawSystems, rawSystem)
 					}
-					rawSystems = append(rawSystems, rawSystem)
-				}
 				}
 			}
 		}
@@ -458,22 +458,22 @@ func (systems *Systems) GetScopedSystems(client *Client, groups *Groups, tags *T
 			}
 
 			talkgroupMap := TalkgroupMap{
-				"id":                      rawTalkgroup.TalkgroupRef,
-				"talkgroupId":             rawTalkgroup.Id,           // Database ID for admin/backend use
-				"talkgroupRef":            rawTalkgroup.TalkgroupRef, // Radio reference ID
-				"frequency":               rawTalkgroup.Frequency,
-				"group":                   groupLabel,
-				"groups":                  groupLabels,
-				"label":                   rawTalkgroup.Label,
-				"name":                    rawTalkgroup.Name,
-				"order":                   rawTalkgroup.Order,
-				"tag":                     tag.Label,
-				"type":                    rawTalkgroup.Kind,
-				"toneDetectionEnabled":    rawTalkgroup.ToneDetectionEnabled,
-				"toneDownstreamEnabled":   rawTalkgroup.ToneDownstreamEnabled,
-				"toneDownstreamURL":       rawTalkgroup.ToneDownstreamURL,
-				"toneDownstreamAPIKey":    rawTalkgroup.ToneDownstreamAPIKey,
-				"alertsEnabled":           rawTalkgroup.AlertsEnabled,
+				"id":                    rawTalkgroup.TalkgroupRef,
+				"talkgroupId":           rawTalkgroup.Id,           // Database ID for admin/backend use
+				"talkgroupRef":          rawTalkgroup.TalkgroupRef, // Radio reference ID
+				"frequency":             rawTalkgroup.Frequency,
+				"group":                 groupLabel,
+				"groups":                groupLabels,
+				"label":                 rawTalkgroup.Label,
+				"name":                  rawTalkgroup.Name,
+				"order":                 rawTalkgroup.Order,
+				"tag":                   tag.Label,
+				"type":                  rawTalkgroup.Kind,
+				"toneDetectionEnabled":  rawTalkgroup.ToneDetectionEnabled,
+				"toneDownstreamEnabled": rawTalkgroup.ToneDownstreamEnabled,
+				"toneDownstreamURL":     rawTalkgroup.ToneDownstreamURL,
+				"toneDownstreamAPIKey":  rawTalkgroup.ToneDownstreamAPIKey,
+				"alertsEnabled":         rawTalkgroup.AlertsEnabled,
 			}
 
 			if len(rawTalkgroup.ToneSets) > 0 {

--- a/server/system_alert.go
+++ b/server/system_alert.go
@@ -352,7 +352,7 @@ func (controller *Controller) MonitorTranscriptionFailures() {
 			repeatMinutes = 60 // Default: 60 minutes
 		}
 
-	checkAlertQuery := `SELECT MAX("createdAt") FROM "systemAlerts" 
+		checkAlertQuery := `SELECT MAX("createdAt") FROM "systemAlerts" 
 		WHERE "alertType" = 'transcription_failure' 
 			AND "dismissed" = false`
 
@@ -469,7 +469,7 @@ func (controller *Controller) MonitorToneDetectionIssues() {
 				repeatMinutes = 60 // Default: 60 minutes
 			}
 
-		checkAlertQuery := fmt.Sprintf(`
+			checkAlertQuery := fmt.Sprintf(`
 			SELECT MAX("createdAt") FROM "systemAlerts" 
 			WHERE "alertType" = 'tone_detection_issue' 
 				AND "data" LIKE '%%"talkgroupId":%d%%'
@@ -531,7 +531,7 @@ func (controller *Controller) MonitorNoAudioForSystem(systemId uint64, systemLab
 
 	var timeSinceLastCall time.Duration
 	var lastCallTimeMs int64
-	
+
 	// If no calls found, treat as infinite time since last call
 	if !lastCallTime.Valid {
 		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio monitoring: system '%s' (ID: %d) has no calls in database - will create alert", systemLabel, systemId))
@@ -543,17 +543,17 @@ func (controller *Controller) MonitorNoAudioForSystem(systemId uint64, systemLab
 		lastCall := time.Unix(lastCallTime.Int64/1000, 0)
 		timeSinceLastCall = currentTime.Sub(lastCall)
 		lastCallTimeMs = lastCallTime.Int64
-		
-		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio check: system '%s' (ID: %d) last call was %d minutes ago (threshold: %d minutes)", 
+
+		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio check: system '%s' (ID: %d) last call was %d minutes ago (threshold: %d minutes)",
 			systemLabel, systemId, int(timeSinceLastCall.Minutes()), thresholdMinutes))
 	}
 
 	// Check if time since last call exceeds threshold
 	thresholdDuration := time.Duration(thresholdMinutes) * time.Minute
 	if timeSinceLastCall > thresholdDuration {
-		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio threshold exceeded for system '%s' (ID: %d): %d minutes since last call (threshold: %d minutes)", 
+		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio threshold exceeded for system '%s' (ID: %d): %d minutes since last call (threshold: %d minutes)",
 			systemLabel, systemId, int(timeSinceLastCall.Minutes()), thresholdMinutes))
-		
+
 		// Check for existing alert
 		repeatMinutes := int(controller.Options.NoAudioRepeatMinutes)
 		if repeatMinutes <= 0 {
@@ -576,15 +576,15 @@ func (controller *Controller) MonitorNoAudioForSystem(systemId uint64, systemLab
 			if lastAlertTime.Int64 > repeatThreshold {
 				shouldCreateAlert = false
 				minutesSinceLastAlert := int(currentTime.Sub(time.UnixMilli(lastAlertTime.Int64)).Minutes())
-				controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("skipping no-audio alert for system '%s' (ID: %d) - alert created %d minutes ago (repeat interval: %d minutes)", 
+				controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("skipping no-audio alert for system '%s' (ID: %d) - alert created %d minutes ago (repeat interval: %d minutes)",
 					systemLabel, systemId, minutesSinceLastAlert, repeatMinutes))
 			}
 		}
 
 		if shouldCreateAlert {
-		// Dismiss any existing no-audio alerts for this system before creating new one
-		// This keeps only the latest alert instead of accumulating them
-		dismissQuery := fmt.Sprintf(`
+			// Dismiss any existing no-audio alerts for this system before creating new one
+			// This keeps only the latest alert instead of accumulating them
+			dismissQuery := fmt.Sprintf(`
 			UPDATE "systemAlerts" 
 			SET "dismissed" = true 
 			WHERE "alertType" = 'no_audio' 
@@ -630,7 +630,7 @@ func (controller *Controller) MonitorNoAudioForSystem(systemId uint64, systemLab
 			}
 		}
 	} else {
-		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio check OK: system '%s' (ID: %d) within threshold - %d minutes since last call (threshold: %d minutes)", 
+		controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("no-audio check OK: system '%s' (ID: %d) within threshold - %d minutes since last call (threshold: %d minutes)",
 			systemLabel, systemId, int(timeSinceLastCall.Minutes()), thresholdMinutes))
 	}
 }

--- a/server/talkgroup.go
+++ b/server/talkgroup.go
@@ -26,18 +26,18 @@ import (
 )
 
 type Talkgroup struct {
-	Id                      uint64
-	Delay                   uint
-	Frequency               uint
-	GroupIds                []uint64
-	Kind                    string
-	Label                   string
-	Name                    string
-	Order                   uint
-	TagId                   uint64
-	TalkgroupRef            uint
-	ToneDetectionEnabled     bool
-	ToneSets                 []ToneSet
+	Id                   uint64
+	Delay                uint
+	Frequency            uint
+	GroupIds             []uint64
+	Kind                 string
+	Label                string
+	Name                 string
+	Order                uint
+	TagId                uint64
+	TalkgroupRef         uint
+	ToneDetectionEnabled bool
+	ToneSets             []ToneSet
 	// Per-channel TonesToActive forwarding (forwards all tone sets for this talkgroup)
 	ToneDownstreamEnabled bool   `json:"toneDownstreamEnabled"`
 	ToneDownstreamURL     string `json:"toneDownstreamURL"`
@@ -51,8 +51,8 @@ type Talkgroup struct {
 	// voice call within LinkedVoiceWindowSeconds. Useful when an agency pages on a dedicated signalling
 	// channel (TGID A) but dispatches voice on a separate tactical channel (TGID B).
 	// 0 values disable the feature (default, fully backward compatible).
-	LinkedVoiceTalkgroupRef      uint `json:"linkedVoiceTalkgroupRef"`
-	LinkedVoiceWindowSeconds     uint `json:"linkedVoiceWindowSeconds"`
+	LinkedVoiceTalkgroupRef       uint `json:"linkedVoiceTalkgroupRef"`
+	LinkedVoiceWindowSeconds      uint `json:"linkedVoiceWindowSeconds"`
 	LinkedVoiceMinDurationSeconds uint `json:"linkedVoiceMinDurationSeconds"`
 
 	// Admin toggle: false suppresses all alerts & transcription for this talkgroup regardless of user prefs.

--- a/server/transcription_azure.go
+++ b/server/transcription_azure.go
@@ -177,4 +177,3 @@ func (azure *AzureTranscription) GetSupportedLanguages() []string {
 
 // Note: convertToWAV function is shared with AssemblyAI transcription provider
 // It's defined in transcription_assemblyai.go since both are in the same package
-

--- a/server/transcription_google.go
+++ b/server/transcription_google.go
@@ -29,11 +29,11 @@ import (
 
 // GoogleTranscription implements TranscriptionProvider for Google Cloud Speech-to-Text
 type GoogleTranscription struct {
-	available     bool
-	apiKey        string
-	credentials   string // Service account JSON (alternative to API key)
-	httpClient    *http.Client
-	warned        bool
+	available   bool
+	apiKey      string
+	credentials string // Service account JSON (alternative to API key)
+	httpClient  *http.Client
+	warned      bool
 }
 
 // GoogleConfig contains configuration for Google Cloud Speech-to-Text
@@ -84,9 +84,9 @@ func (google *GoogleTranscription) Transcribe(audio []byte, options Transcriptio
 	// Build request body
 	requestBody := map[string]interface{}{
 		"config": map[string]interface{}{
-			"encoding":        google.getAudioEncoding(options.AudioMime),
-			"sampleRateHertz": 16000, // Default, may need adjustment based on actual audio
-			"languageCode":    language,
+			"encoding":                   google.getAudioEncoding(options.AudioMime),
+			"sampleRateHertz":            16000, // Default, may need adjustment based on actual audio
+			"languageCode":               language,
 			"enableAutomaticPunctuation": true,
 			"enableWordTimeOffsets":      true,
 		},
@@ -113,7 +113,7 @@ func (google *GoogleTranscription) Transcribe(audio []byte, options Transcriptio
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	
+
 	// If using service account credentials, we'd need OAuth2 token
 	// For now, API key is simpler
 	if google.credentials != "" && google.apiKey == "" {
@@ -136,12 +136,12 @@ func (google *GoogleTranscription) Transcribe(audio []byte, options Transcriptio
 	var googleResponse struct {
 		Results []struct {
 			Alternatives []struct {
-				Transcript string `json:"transcript"`
+				Transcript string  `json:"transcript"`
 				Confidence float64 `json:"confidence"`
 				Words      []struct {
-					StartTime  string `json:"startTime"`
-					EndTime    string `json:"endTime"`
-					Word       string `json:"word"`
+					StartTime string `json:"startTime"`
+					EndTime   string `json:"endTime"`
+					Word      string `json:"word"`
 				} `json:"words"`
 			} `json:"alternatives"`
 		} `json:"results"`
@@ -170,7 +170,7 @@ func (google *GoogleTranscription) Transcribe(audio []byte, options Transcriptio
 		// In a more sophisticated implementation, you could group by time gaps
 		startTime := google.parseTime(bestAlternative.Words[0].StartTime)
 		endTime := google.parseTime(bestAlternative.Words[len(bestAlternative.Words)-1].EndTime)
-		
+
 		segments = append(segments, TranscriptSegment{
 			Text:       transcript,
 			StartTime:  startTime,
@@ -243,4 +243,3 @@ func (google *GoogleTranscription) GetSupportedLanguages() []string {
 		"hu-HU", "id-ID", "ms-MY", "no-NO", "ro-RO", "sk-SK", "sv-SE", "uk-UA", "vi-VN",
 	}
 }
-

--- a/server/transcription_hydra.go
+++ b/server/transcription_hydra.go
@@ -41,16 +41,16 @@ type HydraTranscriptionRetrievalJob struct {
 
 // HydraTranscriptionRetrievalQueue manages retrieval of transcriptions from Hydra API
 type HydraTranscriptionRetrievalQueue struct {
-	jobs       chan HydraTranscriptionRetrievalJob
-	controller *Controller
-	mutex      sync.Mutex
-	running    bool
-	stopChan   chan struct{}
-	apiSecret  string // Node secret for authentication
-	jwtToken   string // JWT token obtained from /auth/node
-	tokenExpiry time.Time // When the JWT expires
+	jobs              chan HydraTranscriptionRetrievalJob
+	controller        *Controller
+	mutex             sync.Mutex
+	running           bool
+	stopChan          chan struct{}
+	apiSecret         string    // Node secret for authentication
+	jwtToken          string    // JWT token obtained from /auth/node
+	tokenExpiry       time.Time // When the JWT expires
 	lastNoJobsLogTime time.Time // Last time we logged "no jobs ready" message
-	pollCount int // Counter for debugging polling
+	pollCount         int       // Counter for debugging polling
 }
 
 // NewHydraTranscriptionRetrievalQueue creates a new Hydra transcription retrieval queue
@@ -233,7 +233,7 @@ func (queue *HydraTranscriptionRetrievalQueue) processBatch() {
 
 	// Collect up to 15 jobs from the queue, but only process those that have waited at least 15 seconds
 	now := time.Now()
-	
+
 	// Log when we start checking for jobs (first few times to confirm polling is working)
 	queue.mutex.Lock()
 	pollCount := queue.pollCount
@@ -244,7 +244,7 @@ func (queue *HydraTranscriptionRetrievalQueue) processBatch() {
 	}
 	readyJobs := make([]HydraTranscriptionRetrievalJob, 0, 15)
 	pendingJobs := make([]HydraTranscriptionRetrievalJob, 0)
-	
+
 	// Drain all available jobs from the channel
 	draining := true
 	for draining && len(readyJobs) < 15 && len(pendingJobs) < 100 {
@@ -329,33 +329,33 @@ func (queue *HydraTranscriptionRetrievalQueue) retrieveTranscription(job HydraTr
 		queue.mutex.Lock()
 		queue.jwtToken = "" // Clear invalid token
 		queue.mutex.Unlock()
-		
+
 		if err := queue.authenticate(); err != nil {
 			log.Printf("Hydra retrieval: re-authentication failed: %v", err)
 			return
 		}
-		
+
 		// Retry the request with new token
 		queue.mutex.Lock()
 		jwtToken = queue.jwtToken
 		queue.mutex.Unlock()
-		
+
 		req2, _ := http.NewRequest("GET", url, nil)
 		req2.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwtToken))
 		req2.Header.Set("Content-Type", "application/json")
-		
+
 		resp2, err := client.Do(req2)
 		if err != nil {
 			log.Printf("Hydra retrieval: retry failed for call %d: %v", job.CallId, err)
 			return
 		}
 		defer resp2.Body.Close()
-		
+
 		if resp2.StatusCode != http.StatusOK {
 			log.Printf("Hydra retrieval: Hydra returned %d for call %d (transmission_id=%s) after re-auth", resp2.StatusCode, job.CallId, job.TransmissionId)
 			return
 		}
-		
+
 		// Use resp2 for decoding
 		resp = resp2
 	} else if resp.StatusCode != http.StatusOK {
@@ -378,7 +378,7 @@ func (queue *HydraTranscriptionRetrievalQueue) retrieveTranscription(job HydraTr
 		log.Printf("Hydra retrieval: failed to read Hydra response for call %d: %v", job.CallId, err)
 		return
 	}
-	
+
 	// Log raw Hydra response for debugging transcript mismatches
 	bodyStr := string(bodyBytes)
 	if len(bodyStr) > 500 {
@@ -432,7 +432,7 @@ func (queue *HydraTranscriptionRetrievalQueue) retrieveTranscription(job HydraTr
 		log.Printf("Hydra retrieval: failed to verify call %d exists: %v", job.CallId, err)
 		return
 	}
-	
+
 	// Verify transmission_id matches
 	if dbTransmissionId != job.TransmissionId {
 		log.Printf("Hydra retrieval: WARNING - transmission_id mismatch for call %d: stored=%q, expected=%q, skipping transcript storage", job.CallId, dbTransmissionId, job.TransmissionId)
@@ -452,7 +452,7 @@ func (queue *HydraTranscriptionRetrievalQueue) retrieveTranscription(job HydraTr
 		log.Printf("Hydra retrieval: failed to update call transcript for call %d: %v", job.CallId, err)
 		return
 	}
-	
+
 	// Verify the update actually affected a row
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -488,7 +488,7 @@ func (queue *HydraTranscriptionRetrievalQueue) UpdateAPIKey(apiSecret string) {
 	defer queue.mutex.Unlock()
 	oldSecret := queue.apiSecret
 	queue.apiSecret = apiSecret
-	
+
 	// If secret changed, invalidate token to force re-auth
 	if oldSecret != apiSecret {
 		queue.jwtToken = ""

--- a/server/transcription_queue.go
+++ b/server/transcription_queue.go
@@ -38,13 +38,13 @@ type TranscriptionJob struct {
 
 // TranscriptionQueue manages transcription jobs with a worker pool
 type TranscriptionQueue struct {
-	jobs            chan TranscriptionJob
-	workers         int
-	provider        TranscriptionProvider
-	controller      *Controller
-	mutex           sync.Mutex
-	running         bool
-	processedCount  atomic.Uint64 // total transcriptions completed since startup
+	jobs           chan TranscriptionJob
+	workers        int
+	provider       TranscriptionProvider
+	controller     *Controller
+	mutex          sync.Mutex
+	running        bool
+	processedCount atomic.Uint64 // total transcriptions completed since startup
 }
 
 // NewTranscriptionQueue creates a new transcription queue with worker pool

--- a/server/transcription_whisper_api.go
+++ b/server/transcription_whisper_api.go
@@ -417,4 +417,3 @@ func (api *WhisperAPITranscription) GetSupportedLanguages() []string {
 		"hu", "id", "ms", "no", "ro", "sk", "sv", "uk", "vi",
 	}
 }
-

--- a/server/transfer_request.go
+++ b/server/transfer_request.go
@@ -38,7 +38,7 @@ type TransferRequest struct {
 }
 
 type TransferRequests struct {
-	mutex sync.RWMutex
+	mutex    sync.RWMutex
 	requests map[uint64]*TransferRequest
 }
 
@@ -198,4 +198,3 @@ func (trs *TransferRequests) Delete(id uint64, db *Database) error {
 
 	return nil
 }
-

--- a/server/validation.go
+++ b/server/validation.go
@@ -10,7 +10,7 @@ import (
 var (
 	// Email regex pattern - RFC 5322 compliant (simplified but practical)
 	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
-	
+
 	// Max email length per RFC 5321
 	maxEmailLength = 254
 )
@@ -21,40 +21,40 @@ func ValidateEmail(email string) error {
 	if email == "" {
 		return fmt.Errorf("email is required")
 	}
-	
+
 	// Trim whitespace
 	email = strings.TrimSpace(email)
-	
+
 	// Check length
 	if len(email) > maxEmailLength {
 		return fmt.Errorf("email must be 254 characters or less")
 	}
-	
+
 	// Check format
 	if !emailRegex.MatchString(email) {
 		return fmt.Errorf("invalid email format")
 	}
-	
+
 	// Additional checks
 	if strings.HasPrefix(email, ".") || strings.HasPrefix(email, "@") {
 		return fmt.Errorf("invalid email format")
 	}
-	
+
 	if strings.Contains(email, "..") {
 		return fmt.Errorf("invalid email format")
 	}
-	
+
 	// Split to check domain
 	parts := strings.Split(email, "@")
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid email format")
 	}
-	
+
 	domain := parts[1]
 	if len(domain) == 0 || !strings.Contains(domain, ".") {
 		return fmt.Errorf("invalid email format")
 	}
-	
+
 	return nil
 }
 
@@ -89,24 +89,24 @@ func ValidatePasswordStrength(password string, strength PasswordStrength) error 
 	if password == "" {
 		return fmt.Errorf("password is required")
 	}
-	
+
 	// Check minimum length
 	if len(password) < strength.MinLength {
 		return fmt.Errorf("password must be at least %d characters", strength.MinLength)
 	}
-	
+
 	// Check maximum length (prevent DoS)
 	if len(password) > 128 {
 		return fmt.Errorf("password must be 128 characters or less")
 	}
-	
+
 	var (
 		hasUpper   = false
 		hasLower   = false
 		hasNumber  = false
 		hasSpecial = false
 	)
-	
+
 	// Check character requirements
 	for _, char := range password {
 		switch {
@@ -120,10 +120,10 @@ func ValidatePasswordStrength(password string, strength PasswordStrength) error 
 			hasSpecial = true
 		}
 	}
-	
+
 	// Build error message for missing requirements
 	var missing []string
-	
+
 	if strength.RequireUpper && !hasUpper {
 		missing = append(missing, "uppercase letter")
 	}
@@ -136,11 +136,11 @@ func ValidatePasswordStrength(password string, strength PasswordStrength) error 
 	if strength.RequireSpecial && !hasSpecial {
 		missing = append(missing, "special character")
 	}
-	
+
 	if len(missing) > 0 {
 		return fmt.Errorf("password must contain at least one %s", strings.Join(missing, ", "))
 	}
-	
+
 	return nil
 }
 
@@ -148,4 +148,3 @@ func ValidatePasswordStrength(password string, strength PasswordStrength) error 
 func ValidatePassword(password string) error {
 	return ValidatePasswordStrength(password, DefaultPasswordStrength())
 }
-


### PR DESCRIPTION
This PR formats the `/server` directory with the `go fmt` command to bring it in line with standard Go formatting conventions.

This should reduce noisy diffs in future commits and PRs by applying consistent formatting now.

No functional changes were made.