### PR TITLE
Feature: Configurable transcript parser with annoation rendering

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/admin.module.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.module.ts
@@ -51,6 +51,7 @@ import { RequestAPIKeyDialogComponent } from './config/options/request-api-key-d
 import { RecoverAPIKeyDialogComponent } from './config/options/recover-api-key-dialog.component';
 import { RdioScannerAdminUserGroupsComponent } from './config/user-groups/user-groups.component';
 import { RdioScannerAdminKeywordListsComponent } from './config/keyword-lists/keyword-lists.component';
+import { RdioScannerAdminTranscriptParserComponent } from './config/transcript-parser/transcript-parser.component';
 import { RdioScannerAdminLoginComponent } from './login/login.component';
 import { AlertsService } from '../alerts/alerts.service';
 import { RdioScannerAdminLogsComponent } from './logs/logs.component';
@@ -102,6 +103,7 @@ import { RdioScannerAdminSystemHealthComponent } from './system-health/system-he
         RdioScannerAdminUnitComponent,
         RdioScannerAdminRadioReferenceImportComponent,
         RdioScannerAdminKeywordListsComponent,
+        RdioScannerAdminTranscriptParserComponent,
         RdioScannerAdminConfigSyncComponent,
         RdioScannerAdminStripeSyncComponent,
         RdioScannerAdminPurgeDataComponent,

--- a/client/src/app/components/rdio-scanner/admin/config/config.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/config.component.html
@@ -132,6 +132,13 @@
             <span>Keyword Lists</span>
         </button>
 
+        <button type="button" class="sidebar-item"
+                [class.active]="activeSection === 'transcript-parser'"
+                (click)="setSection('transcript-parser')">
+            <mat-icon>record_voice_over</mat-icon>
+            <span>Transcript Parser</span>
+        </button>
+
         <!-- Save / Reset at bottom of sidebar (hidden when header bar owns them) -->
         <div class="sidebar-actions" *ngIf="!hideActions">
             <button type="button" mat-raised-button class="btn-reset"
@@ -262,6 +269,14 @@
                     <h3>Keyword Lists</h3>
                 </div>
                 <rdio-scanner-admin-keyword-lists></rdio-scanner-admin-keyword-lists>
+            </ng-container>
+
+            <ng-container *ngSwitchCase="'transcript-parser'">
+                <div class="section-header">
+                    <mat-icon>record_voice_over</mat-icon>
+                    <h3>Transcript Parser</h3>
+                </div>
+                <rdio-scanner-admin-transcript-parser></rdio-scanner-admin-transcript-parser>
             </ng-container>
 
         </ng-container>

--- a/client/src/app/components/rdio-scanner/admin/config/transcript-parser/transcript-parser.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/transcript-parser/transcript-parser.component.html
@@ -1,0 +1,373 @@
+<div class="tp-container">
+
+    <!-- Top action bar -->
+    <div class="tp-actions">
+        <button mat-raised-button color="primary" (click)="save()" [disabled]="saving || loading">
+            <mat-icon>save</mat-icon>
+            {{ saving ? 'Saving…' : 'Save' }}
+        </button>
+        <button mat-stroked-button (click)="reset()" [disabled]="saving || loading">
+            <mat-icon>refresh</mat-icon>
+            Reset
+        </button>
+    </div>
+
+    <mat-spinner *ngIf="loading" diameter="40" class="tp-spinner"></mat-spinner>
+
+    <div *ngIf="!loading" class="tp-intro">
+        <button mat-button class="tp-docs-toggle" (click)="showDocs = !showDocs">
+            <mat-icon>{{ showDocs ? 'expand_less' : 'help_outline' }}</mat-icon>
+            {{ showDocs ? 'Hide documentation' : 'How does this work?' }}
+        </button>
+
+        <div *ngIf="showDocs" class="tp-docs">
+            <p>Note: This is optimized for fire department dispatches</p>
+
+            <p>
+                The transcript parser identifies apparatus units and dispatch channels in
+                call transcripts and highlights them in the UI. Configure the word lists
+                below to match the terminology used in your area, then click <strong>Save</strong>.
+                Changes apply retroactively; past calls are re-annotated on the next view.
+            </p>
+
+            <div class="tp-how-it-works">
+                <strong>How it works</strong>
+                <ol>
+                    <li>
+                        <strong>Corrections</strong> are applied first: common STT mis-transcriptions
+                        (e.g. <code>SHORT HALL</code> → <code>SHORT FALL</code>) are fixed before any
+                        parsing runs.
+                    </li>
+                    <li>
+                        <strong>Units</strong> are matched as <em>[Prefix] Unit# Number</em>.
+                        An optional prefix (e.g. <code>MEDIC</code>, <code>BRUSH</code>) can precede
+                        the unit type. Examples: <code>ENGINE 5</code>, <code>MEDIC LADDER 3</code>,
+                        <code>BRUSH ENGINE 2</code>.
+                    </li>
+                    <li>
+                        <strong>Channels</strong> are matched as <em>Dispatch [Separator] Number</em>.
+                        If channel separators are configured the format is
+                        <code>CITY FIRE 3</code>; without separators it is <code>CITY 3</code>.
+                        Shorthands let abbreviated labels like <code>CF 3</code> map to a full
+                        dispatch name.
+                    </li>
+                    <li>
+                        All matching supports <strong>fuzzy</strong> recognition. Set Max Distance
+                        to 1 or 2 to catch common STT mishearings like <code>ENGNE</code> for
+                        <code>ENGINE</code>. Set it to 0 for exact-only matching.
+                        <strong>Aliases</strong> are alternative spellings that are treated as exact
+                        matches regardless of distance.
+                    </li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <mat-accordion *ngIf="!loading" multi>
+
+        <!-- ── Unit Types ──────────────────────────────────────────────────── -->
+        <mat-expansion-panel>
+            <mat-expansion-panel-header>
+                <mat-panel-title>Unit Types</mat-panel-title>
+                <mat-panel-description>{{ config.unitTypes.length }} configured</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <p class="tp-section-desc">
+                The apparatus type portion of a unit identifier, the word that comes before
+                the unit number (and after the optional prefix).
+                <br>
+                <strong>Examples:</strong> <code>ENGINE</code>, <code>TRUCK</code>,
+                <code>LADDER</code>, <code>RESCUE</code>, <code>BATTALION</code>,
+                <code>HAZMAT</code>, <code>MEDIC</code>.
+                <br>
+                Use <em>Aliases</em> for alternate spellings the STT engine produces
+                (<code>TREK</code> → <code>TRUCK</code>).
+                Use <em>Reject if preceded by</em> to avoid false positives, e.g. add
+                <code>ELEVATOR</code> to prevent matching <code>RESCUE 160</code> in
+                "ELEVATOR RESCUE 160 SOUTH MAIN ST".
+            </p>
+
+            <ng-container *ngTemplateOutlet="fuzzyTable; context: { listKey: 'unitTypes', showReject: true }">
+            </ng-container>
+        </mat-expansion-panel>
+
+        <!-- ── Unit Prefixes ──────────────────────────────────────────────── -->
+        <mat-expansion-panel>
+            <mat-expansion-panel-header>
+                <mat-panel-title>Unit Prefixes</mat-panel-title>
+                <mat-panel-description>{{ config.unitPrefixes.length }} configured</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <p class="tp-section-desc">
+                Optional words that appear <em>before</em> a unit type and are included
+                in the highlighted span. Multi-word prefixes are supported.
+                <br>
+                <strong>Examples:</strong> <code>MEDIC</code> (as in <code>MEDIC ENGINE 5</code>),
+                <code>HEAVY</code>, <code>TACTICAL</code>.
+            </p>
+
+            <ng-container *ngTemplateOutlet="fuzzyTable; context: { listKey: 'unitPrefixes', showReject: false }">
+            </ng-container>
+        </mat-expansion-panel>
+
+        <!-- ── Dispatch Names ─────────────────────────────────────────────── -->
+        <mat-expansion-panel>
+            <mat-expansion-panel-header>
+                <mat-panel-title>Dispatch Names</mat-panel-title>
+                <mat-panel-description>{{ config.dispatchNames.length }} configured</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <p class="tp-section-desc">
+                The agency or zone name that starts a channel reference.
+                <br>
+                <strong>Examples:</strong> <code>CITY</code>, <code>OPS</code>,
+                <code>COUNTY</code>, <code>METRO</code>.
+                <br>
+                Use aliases for common mis-transcriptions of the agency name
+                (<code>VEC</code>, <code>DECK</code> → <code>VECC</code>).
+            </p>
+
+            <ng-container *ngTemplateOutlet="fuzzyTable; context: { listKey: 'dispatchNames', showReject: false }">
+            </ng-container>
+        </mat-expansion-panel>
+
+        <!-- ── Channel Separators ─────────────────────────────────────────── -->
+        <mat-expansion-panel>
+            <mat-expansion-panel-header>
+                <mat-panel-title>Channel Separators</mat-panel-title>
+                <mat-panel-description>{{ config.channelSeparators.length }} configured</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <p class="tp-section-desc">
+                The word between a dispatch name and a channel number.
+                Leave this list <em>empty</em> if your channels are formatted
+                as <code>DISPATCH NUMBER</code> (e.g. <code>CITY 3</code>).
+                When configured the expected format is
+                <code>DISPATCH SEPARATOR NUMBER</code>.
+                <br>
+                <strong>Examples:</strong> <code>FIRE</code> (→ <code>CITY FIRE 3</code>),
+                <code>POLICE</code> (→ <code>METRO POLICE 2</code>),
+                <code>EMS</code>, <code>OPS</code>.
+            </p>
+
+            <ng-container *ngTemplateOutlet="fuzzyTable; context: { listKey: 'channelSeparators', showReject: false }">
+            </ng-container>
+        </mat-expansion-panel>
+
+        <!-- ── Channel Shorthands ─────────────────────────────────────────── -->
+        <mat-expansion-panel>
+            <mat-expansion-panel-header>
+                <mat-panel-title>Channel Shorthands</mat-panel-title>
+                <mat-panel-description>{{ config.channelShorthands.length }} configured</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <p class="tp-section-desc">
+                Abbreviated channel labels that map to a full dispatch name. Shorthands
+                are matched exactly and support space, dash, or no separator before the
+                number (<code>SF 3</code>, <code>SF-3</code>, and <code>SF3</code> all work).
+                <br>
+                <strong>Label:</strong> the short text as spoken/transcribed
+                (e.g. <code>SF</code>, <code>BACKFIRE</code>, <code>X-FIRE</code>).
+                <br>
+                <strong>Dispatch:</strong> the canonical agency name to store
+                (e.g. <code>SANDY</code>, <code>VECC</code>).
+                <br>
+                <strong>Separator</strong> (optional): the separator word to record alongside
+                the channel (e.g. <code>FIRE</code>). Leave blank if not applicable.
+            </p>
+
+            <div class="tp-table-wrap">
+                <div class="tp-header-row tp-sh-row">
+                    <span>Label</span>
+                    <span>Dispatch</span>
+                    <span>Separator</span>
+                    <span></span>
+                </div>
+
+                <ng-container *ngFor="let sh of config.channelShorthands; let i = index">
+                    <!-- Display row -->
+                    <div class="tp-row tp-sh-row" *ngIf="editingShorthand !== i">
+                        <span class="tp-word">{{ sh.label }}</span>
+                        <span>{{ sh.dispatch }}</span>
+                        <span>{{ sh.separator || '—' }}</span>
+                        <span class="tp-row-actions">
+                            <button mat-icon-button (click)="editShorthand(i)" title="Edit">
+                                <mat-icon>edit</mat-icon>
+                            </button>
+                            <button mat-icon-button color="warn" (click)="deleteShorthand(i)" title="Delete">
+                                <mat-icon>delete</mat-icon>
+                            </button>
+                        </span>
+                    </div>
+
+                    <!-- Inline edit form -->
+                    <div class="tp-edit-block" *ngIf="editingShorthand === i && editingShorthandData">
+                        <div class="tp-edit-fields-row">
+                            <mat-form-field appearance="outline" class="tp-field-word">
+                                <mat-label>Label</mat-label>
+                                <input matInput [(ngModel)]="editingShorthandData.label" placeholder="SF">
+                            </mat-form-field>
+                            <mat-form-field appearance="outline" class="tp-field-word">
+                                <mat-label>Dispatch</mat-label>
+                                <input matInput [(ngModel)]="editingShorthandData.dispatch" placeholder="SANDY">
+                            </mat-form-field>
+                            <mat-form-field appearance="outline" class="tp-field-dist">
+                                <mat-label>Separator</mat-label>
+                                <input matInput [(ngModel)]="editingShorthandData.separator" placeholder="FIRE">
+                            </mat-form-field>
+                        </div>
+                        <div class="tp-edit-btns">
+                            <button mat-button (click)="cancelShorthand()">Cancel</button>
+                            <button mat-raised-button color="primary"
+                                    (click)="saveShorthand()"
+                                    [disabled]="!editingShorthandData.label || !editingShorthandData.dispatch">
+                                Save
+                            </button>
+                        </div>
+                    </div>
+                </ng-container>
+
+                <div class="tp-add-row">
+                    <button mat-stroked-button (click)="addShorthand()">
+                        <mat-icon>add</mat-icon> Add Shorthand
+                    </button>
+                </div>
+            </div>
+        </mat-expansion-panel>
+
+        <!-- ── Corrections ────────────────────────────────────────────────── -->
+        <mat-expansion-panel>
+            <mat-expansion-panel-header>
+                <mat-panel-title>Corrections</mat-panel-title>
+                <mat-panel-description>Common mis-transcriptions to fix before parsing</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <p class="tp-section-desc">
+                Plain-text replacements applied to the raw transcript <em>before</em> any
+                unit or channel parsing runs. The corrected text is what gets stored and
+                displayed to clients.
+                Use <em>Aliases</em> for the wrong forms; the <em>Word</em> field is the
+                correct replacement.
+                <br>
+                <strong>Examples:</strong>
+                <code>SHORT HALL</code> → <code>SHORT FALL</code>;
+                <code>A KNOWN MEDICAL</code> → <code>UNKNOWN MEDICAL</code> (common
+                mishearing of "an unknown medical").
+                <br>
+                Max Distance works here too: set it to 1–2 to catch slight variations of
+                the wrong form without needing to list every typo as an alias.
+            </p>
+
+            <ng-container *ngTemplateOutlet="fuzzyTable; context: { listKey: 'corrections', showReject: false }">
+            </ng-container>
+        </mat-expansion-panel>
+
+    </mat-accordion>
+
+</div>
+
+<!-- ── Shared FuzzyWord table template ──────────────────────────────────── -->
+<ng-template #fuzzyTable let-listKey="listKey" let-showReject="showReject">
+    <div class="tp-table-wrap">
+        <div class="tp-header-row tp-fw-row">
+            <span>Word</span>
+            <span>Max Distance</span>
+            <span>Aliases</span>
+            <span></span>
+        </div>
+
+        <ng-container *ngFor="let fw of getFuzzyList(listKey); let i = index">
+            <!-- Display row -->
+            <div class="tp-row tp-fw-row" *ngIf="!isEditingFuzzy(listKey, i)">
+                <span class="tp-word">{{ fw.word }}</span>
+                <span>
+                    <span class="tp-dist-badge" [class.tp-dist-exact]="fw.maxDistance === 0">
+                        {{ fw.maxDistance === 0 ? 'exact' : fw.maxDistance }}
+                    </span>
+                </span>
+                <span class="tp-alias-preview">{{ aliasPreview(fw) }}</span>
+                <span class="tp-row-actions">
+                    <button mat-icon-button (click)="editFuzzy(listKey, i)" title="Edit">
+                        <mat-icon>edit</mat-icon>
+                    </button>
+                    <button mat-icon-button color="warn" (click)="deleteFuzzy(listKey, i)" title="Delete">
+                        <mat-icon>delete</mat-icon>
+                    </button>
+                </span>
+            </div>
+
+            <!-- Inline edit form -->
+            <div class="tp-edit-block" *ngIf="isEditingFuzzy(listKey, i) && editingFuzzyData">
+                <div class="tp-edit-fields-row">
+                    <mat-form-field appearance="outline" class="tp-field-word">
+                        <mat-label>Word</mat-label>
+                        <input matInput [(ngModel)]="editingFuzzyData.word" placeholder="ENGINE">
+                    </mat-form-field>
+                    <mat-form-field appearance="outline" class="tp-field-dist">
+                        <mat-label>Max Distance</mat-label>
+                        <input matInput type="number" min="0" max="3"
+                               [(ngModel)]="editingFuzzyData.maxDistance">
+                        <mat-hint>0 = exact match</mat-hint>
+                    </mat-form-field>
+                </div>
+
+                <!-- Aliases chip input -->
+                <div class="tp-chip-section">
+                    <span class="tp-chip-label">Aliases</span>
+                    <div class="tp-chip-row">
+                        <span *ngFor="let alias of editingFuzzyData.aliases; let ai = index" class="tp-chip">
+                            {{ alias }}
+                            <button mat-icon-button class="tp-chip-remove" (click)="removeAlias(ai)">
+                                <mat-icon>close</mat-icon>
+                            </button>
+                        </span>
+                        <mat-form-field appearance="outline" class="tp-chip-input">
+                            <input matInput [(ngModel)]="newAliasText"
+                                   placeholder="Add alias…"
+                                   (keydown)="onAliasKeydown($event)">
+                        </mat-form-field>
+                        <button mat-icon-button (click)="addAlias()" [disabled]="!newAliasText" title="Add alias">
+                            <mat-icon>add</mat-icon>
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Reject chip input (unit types and corrections only) -->
+                <div class="tp-chip-section" *ngIf="showReject">
+                    <span class="tp-chip-label">Reject if preceded by</span>
+                    <div class="tp-chip-row">
+                        <span *ngFor="let rw of editingFuzzyData.reject; let ri = index" class="tp-chip tp-chip-reject">
+                            {{ rw }}
+                            <button mat-icon-button class="tp-chip-remove" (click)="removeReject(ri)">
+                                <mat-icon>close</mat-icon>
+                            </button>
+                        </span>
+                        <mat-form-field appearance="outline" class="tp-chip-input">
+                            <input matInput [(ngModel)]="newRejectText"
+                                   placeholder="Add word…"
+                                   (keydown)="onRejectKeydown($event)">
+                        </mat-form-field>
+                        <button mat-icon-button (click)="addReject()" [disabled]="!newRejectText" title="Add reject word">
+                            <mat-icon>add</mat-icon>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="tp-edit-btns">
+                    <button mat-button (click)="cancelFuzzy()">Cancel</button>
+                    <button mat-raised-button color="primary"
+                            (click)="saveFuzzy()"
+                            [disabled]="!editingFuzzyData.word">
+                        Save
+                    </button>
+                </div>
+            </div>
+        </ng-container>
+
+        <div class="tp-add-row">
+            <button mat-stroked-button (click)="addFuzzy(listKey)">
+                <mat-icon>add</mat-icon> Add Word
+            </button>
+        </div>
+    </div>
+</ng-template>

--- a/client/src/app/components/rdio-scanner/admin/config/transcript-parser/transcript-parser.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/transcript-parser/transcript-parser.component.scss
@@ -1,0 +1,245 @@
+.tp-container {
+    padding: 16px 0;
+}
+
+// ── Intro / documentation ─────────────────────────────────────────────────────
+
+.tp-intro {
+    margin-bottom: 20px;
+    font-size: 14px;
+    line-height: 1.6;
+    opacity: 0.85;
+
+    p {
+        margin: 0 0 12px;
+    }
+}
+
+.tp-how-it-works {
+    padding: 12px 16px;
+    border-left: 3px solid rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 0 4px 4px 0;
+
+    > strong {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        opacity: 0.7;
+    }
+
+    ol {
+        margin: 0;
+        padding-left: 20px;
+
+        li {
+            margin-bottom: 6px;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+
+    code {
+        font-family: monospace;
+        font-size: 12px;
+        padding: 1px 5px;
+        border-radius: 3px;
+        background: rgba(255, 255, 255, 0.1);
+    }
+}
+
+.tp-section-desc {
+    font-size: 13px;
+    line-height: 1.6;
+    opacity: 0.75;
+    margin: 0 0 14px;
+
+    code {
+        font-family: monospace;
+        font-size: 12px;
+        padding: 1px 5px;
+        border-radius: 3px;
+        background: rgba(255, 255, 255, 0.1);
+    }
+}
+
+.tp-actions {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 20px;
+}
+
+.tp-spinner {
+    margin: 32px auto;
+    display: block;
+}
+
+// ── Table layout ──────────────────────────────────────────────────────────────
+
+.tp-table-wrap {
+    width: 100%;
+}
+
+.tp-fw-row {
+    display: grid;
+    grid-template-columns: 1fr 120px 1fr 80px;
+    align-items: center;
+    gap: 8px;
+}
+
+.tp-sh-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 80px;
+    align-items: center;
+    gap: 8px;
+}
+
+.tp-header-row {
+    padding: 6px 8px;
+    font-size: 12px;
+    font-weight: 600;
+    opacity: 0.6;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.tp-row {
+    padding: 8px;
+    border-radius: 4px;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.04);
+    }
+}
+
+.tp-word {
+    font-family: monospace;
+    font-size: 14px;
+}
+
+.tp-dist-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    background-color: rgba(33, 150, 243, 0.2);
+    color: #90caf9;
+}
+
+.tp-dist-exact {
+    background-color: rgba(76, 175, 80, 0.2);
+    color: #a5d6a7;
+}
+
+.tp-alias-preview {
+    font-size: 13px;
+    opacity: 0.7;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tp-row-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+// ── Inline edit block ─────────────────────────────────────────────────────────
+
+.tp-edit-block {
+    margin: 4px 0 8px 0;
+    padding: 12px 16px;
+    border-left: 3px solid #2196f3;
+    background: rgba(33, 150, 243, 0.05);
+    border-radius: 0 4px 4px 0;
+}
+
+.tp-edit-fields-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.tp-field-word {
+    flex: 1 1 180px;
+}
+
+.tp-field-dist {
+    flex: 0 0 140px;
+}
+
+// ── Chip rows ─────────────────────────────────────────────────────────────────
+
+.tp-chip-section {
+    margin-bottom: 10px;
+}
+
+.tp-chip-label {
+    display: block;
+    font-size: 12px;
+    font-weight: 500;
+    opacity: 0.7;
+    margin-bottom: 6px;
+}
+
+.tp-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.tp-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 4px 2px 10px;
+    border-radius: 16px;
+    background: rgba(33, 150, 243, 0.2);
+    font-size: 13px;
+    font-family: monospace;
+    gap: 2px;
+}
+
+.tp-chip-reject {
+    background: rgba(244, 67, 54, 0.15);
+}
+
+.tp-chip-remove {
+    width: 20px !important;
+    height: 20px !important;
+    line-height: 20px !important;
+
+    mat-icon {
+        font-size: 14px;
+        width: 14px;
+        height: 14px;
+    }
+}
+
+.tp-chip-input {
+    flex: 0 0 160px;
+
+    ::ng-deep .mat-form-field-wrapper {
+        padding-bottom: 0;
+    }
+}
+
+// ── Edit action buttons ───────────────────────────────────────────────────────
+
+.tp-edit-btns {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
+}
+
+// ── Add row ───────────────────────────────────────────────────────────────────
+
+.tp-add-row {
+    padding: 8px 0 4px;
+}

--- a/client/src/app/components/rdio-scanner/admin/config/transcript-parser/transcript-parser.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/transcript-parser/transcript-parser.component.ts
@@ -1,0 +1,307 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Carter Carling <carter@cartercarling.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { firstValueFrom } from 'rxjs';
+import { RdioScannerAdminService } from '../../admin.service';
+
+export interface FuzzyWord {
+    word: string;
+    maxDistance: number;
+    aliases?: string[];
+    reject?: string[];
+}
+
+export interface ChannelShorthand {
+    label: string;
+    dispatch: string;
+    separator?: string;
+}
+
+export interface TranscriptConfig {
+    unitTypes: FuzzyWord[];
+    unitPrefixes: FuzzyWord[];
+    dispatchNames: FuzzyWord[];
+    channelSeparators: FuzzyWord[];
+    channelShorthands: ChannelShorthand[];
+    corrections: FuzzyWord[];
+}
+
+type FuzzyListKey = 'unitTypes' | 'unitPrefixes' | 'dispatchNames' | 'channelSeparators' | 'corrections';
+
+const emptyConfig = (): TranscriptConfig => ({
+    unitTypes: [],
+    unitPrefixes: [],
+    dispatchNames: [],
+    channelSeparators: [],
+    channelShorthands: [],
+    corrections: [],
+});
+
+@Component({
+    selector: 'rdio-scanner-admin-transcript-parser',
+    templateUrl: './transcript-parser.component.html',
+    styleUrls: ['./transcript-parser.component.scss'],
+})
+export class RdioScannerAdminTranscriptParserComponent implements OnInit {
+    config: TranscriptConfig = emptyConfig();
+    loading = false;
+    saving = false;
+    showDocs = false;
+
+    // Fuzzy word editing state
+    editingFuzzy: { listKey: FuzzyListKey; index: number } | null = null;
+    editingFuzzyData: FuzzyWord | null = null;
+    newAliasText = '';
+    newRejectText = '';
+
+    // Channel shorthand editing state
+    editingShorthand: number | null = null;
+    editingShorthandData: ChannelShorthand | null = null;
+
+    constructor(
+        private adminService: RdioScannerAdminService,
+        private http: HttpClient,
+        private snackBar: MatSnackBar,
+    ) {}
+
+    ngOnInit(): void {
+        this.load();
+    }
+
+    async load(): Promise<void> {
+        this.loading = true;
+        try {
+            const res = await firstValueFrom(
+                this.http.get<TranscriptConfig>(
+                    `${window.location.origin}/api/admin/transcript-parser`,
+                    { headers: this.adminService.getAuthHeaders() },
+                ),
+            );
+            this.config = {
+                unitTypes: res.unitTypes || [],
+                unitPrefixes: res.unitPrefixes || [],
+                dispatchNames: res.dispatchNames || [],
+                channelSeparators: res.channelSeparators || [],
+                channelShorthands: res.channelShorthands || [],
+                corrections: res.corrections || [],
+            };
+        } catch {
+            this.snackBar.open('Failed to load transcript parser config', 'Dismiss', { duration: 4000 });
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    async save(): Promise<void> {
+        this.saving = true;
+        try {
+            await firstValueFrom(
+                this.http.put(
+                    `${window.location.origin}/api/admin/transcript-parser`,
+                    this.config,
+                    { headers: this.adminService.getAuthHeaders() },
+                ),
+            );
+            this.snackBar.open('Transcript parser config saved', 'Dismiss', { duration: 3000 });
+        } catch {
+            this.snackBar.open('Failed to save transcript parser config', 'Dismiss', { duration: 4000 });
+        } finally {
+            this.saving = false;
+        }
+    }
+
+    reset(): void {
+        this.cancelFuzzy();
+        this.cancelShorthand();
+        this.load();
+    }
+
+    // ─── FuzzyWord list helpers ───────────────────────────────────────────────
+
+    addFuzzy(listKey: FuzzyListKey): void {
+        const list = this.config[listKey] as FuzzyWord[];
+        list.push({ word: '', maxDistance: 0, aliases: [], reject: [] });
+        this.editFuzzy(listKey, list.length - 1);
+    }
+
+    editFuzzy(listKey: FuzzyListKey, index: number): void {
+        this.cancelShorthand();
+        const original = (this.config[listKey] as FuzzyWord[])[index];
+        this.editingFuzzyData = {
+            word: original.word,
+            maxDistance: original.maxDistance,
+            aliases: [...(original.aliases || [])],
+            reject: [...(original.reject || [])],
+        };
+        this.editingFuzzy = { listKey, index };
+        this.newAliasText = '';
+        this.newRejectText = '';
+    }
+
+    saveFuzzy(): void {
+        if (!this.editingFuzzy || !this.editingFuzzyData) return;
+        const { listKey, index } = this.editingFuzzy;
+        const list = this.config[listKey] as FuzzyWord[];
+        list[index] = {
+            word: this.editingFuzzyData.word.toUpperCase().trim(),
+            maxDistance: Number(this.editingFuzzyData.maxDistance) || 0,
+            aliases: (this.editingFuzzyData.aliases || []).length > 0 ? this.editingFuzzyData.aliases : undefined,
+            reject: (this.editingFuzzyData.reject || []).length > 0 ? this.editingFuzzyData.reject : undefined,
+        };
+        this.cancelFuzzy();
+    }
+
+    cancelFuzzy(): void {
+        // If the row being cancelled is a newly added empty entry, remove it
+        if (this.editingFuzzy && this.editingFuzzyData) {
+            const { listKey, index } = this.editingFuzzy;
+            const list = this.config[listKey] as FuzzyWord[];
+            if (list[index].word === '') {
+                list.splice(index, 1);
+            }
+        }
+        this.editingFuzzy = null;
+        this.editingFuzzyData = null;
+        this.newAliasText = '';
+        this.newRejectText = '';
+    }
+
+    deleteFuzzy(listKey: FuzzyListKey, index: number): void {
+        if (this.editingFuzzy?.listKey === listKey) {
+            if (this.editingFuzzy.index === index) {
+                this.editingFuzzy = null;
+                this.editingFuzzyData = null;
+            } else if (this.editingFuzzy.index > index) {
+                this.editingFuzzy = { ...this.editingFuzzy, index: this.editingFuzzy.index - 1 };
+            }
+        }
+        (this.config[listKey] as FuzzyWord[]).splice(index, 1);
+    }
+
+    isEditingFuzzy(listKey: FuzzyListKey, index: number): boolean {
+        return this.editingFuzzy?.listKey === listKey && this.editingFuzzy?.index === index;
+    }
+
+    // ─── Alias chip helpers ───────────────────────────────────────────────────
+
+    addAlias(): void {
+        const text = this.newAliasText.toUpperCase().trim();
+        if (!text || !this.editingFuzzyData) return;
+        const aliases = this.editingFuzzyData.aliases || [];
+        if (!aliases.includes(text)) {
+            aliases.push(text);
+            this.editingFuzzyData.aliases = aliases;
+        }
+        this.newAliasText = '';
+    }
+
+    removeAlias(index: number): void {
+        this.editingFuzzyData?.aliases?.splice(index, 1);
+    }
+
+    // ─── Reject chip helpers ──────────────────────────────────────────────────
+
+    addReject(): void {
+        const text = this.newRejectText.toUpperCase().trim();
+        if (!text || !this.editingFuzzyData) return;
+        const reject = this.editingFuzzyData.reject || [];
+        if (!reject.includes(text)) {
+            reject.push(text);
+            this.editingFuzzyData.reject = reject;
+        }
+        this.newRejectText = '';
+    }
+
+    removeReject(index: number): void {
+        this.editingFuzzyData?.reject?.splice(index, 1);
+    }
+
+    // ─── ChannelShorthand helpers ─────────────────────────────────────────────
+
+    addShorthand(): void {
+        this.config.channelShorthands.push({ label: '', dispatch: '', separator: '' });
+        this.editShorthand(this.config.channelShorthands.length - 1);
+    }
+
+    editShorthand(index: number): void {
+        this.cancelFuzzy();
+        const original = this.config.channelShorthands[index];
+        this.editingShorthandData = { ...original };
+        this.editingShorthand = index;
+    }
+
+    saveShorthand(): void {
+        if (this.editingShorthand === null || !this.editingShorthandData) return;
+        this.config.channelShorthands[this.editingShorthand] = {
+            label: this.editingShorthandData.label.toUpperCase().trim(),
+            dispatch: this.editingShorthandData.dispatch.toUpperCase().trim(),
+            separator: this.editingShorthandData.separator?.toUpperCase().trim() || undefined,
+        };
+        this.cancelShorthand();
+    }
+
+    cancelShorthand(): void {
+        if (this.editingShorthand !== null && this.editingShorthandData) {
+            const sh = this.config.channelShorthands[this.editingShorthand];
+            if (sh && sh.label === '') {
+                this.config.channelShorthands.splice(this.editingShorthand, 1);
+            }
+        }
+        this.editingShorthand = null;
+        this.editingShorthandData = null;
+    }
+
+    deleteShorthand(index: number): void {
+        if (this.editingShorthand === index) {
+            this.editingShorthand = null;
+            this.editingShorthandData = null;
+        } else if (this.editingShorthand !== null && this.editingShorthand > index) {
+            this.editingShorthand -= 1;
+        }
+        this.config.channelShorthands.splice(index, 1);
+    }
+
+    // ─── Template helpers ─────────────────────────────────────────────────────
+
+    getFuzzyList(listKey: FuzzyListKey): FuzzyWord[] {
+        return this.config[listKey] as FuzzyWord[];
+    }
+
+    aliasPreview(fw: FuzzyWord): string {
+        if (!fw.aliases || fw.aliases.length === 0) return '—';
+        return fw.aliases.slice(0, 3).join(', ') + (fw.aliases.length > 3 ? ', …' : '');
+    }
+
+    onAliasKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.addAlias();
+        }
+    }
+
+    onRejectKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.addReject();
+        }
+    }
+}

--- a/client/src/app/components/rdio-scanner/alerts/alerts.component.html
+++ b/client/src/app/components/rdio-scanner/alerts/alerts.component.html
@@ -92,7 +92,8 @@
                         <p class="summary-text">{{ alert.alertSummary }}</p>
                     </div>
                     <div *ngIf="alert.transcript || alert.transcriptSnippet" class="alert-transcript">
-                        <p class="transcript-text">{{ alert.transcript || alert.transcriptSnippet }}</p>
+                        <p class="transcript-text"
+                           [innerHTML]="renderTranscript(alert.transcript || alert.transcriptSnippet || '', alert.transcriptAnnotations)"></p>
                     </div>
                 </div>
                 <div class="alert-actions">
@@ -183,7 +184,8 @@
                                 </div>
                                 <div *ngIf="alert.transcript || alert.transcriptSnippet" class="alert-transcript">
                                     <strong>Transcript:</strong>
-                                    <p class="transcript-text">{{ alert.transcript || alert.transcriptSnippet }}</p>
+                                    <p class="transcript-text"
+                                       [innerHTML]="renderTranscript(alert.transcript || alert.transcriptSnippet || '', alert.transcriptAnnotations)"></p>
                                 </div>
                             </div>
                         </div>
@@ -267,7 +269,7 @@
                         <strong>Summary:</strong>
                         <p class="summary-text">{{ transcript.alertSummary }}</p>
                     </div>
-                    <p [innerHTML]="highlightSearchText(transcript.transcript, filterSearch)"></p>
+                    <p [innerHTML]="renderTranscript(transcript.transcript, transcript.transcriptAnnotations, filterSearch)"></p>
                 </div>
                 <div class="transcript-footer">
                     <span>{{ transcript.timestamp ? formatTimestamp(transcript.timestamp) : '' }}</span>

--- a/client/src/app/components/rdio-scanner/alerts/alerts.component.scss
+++ b/client/src/app/components/rdio-scanner/alerts/alerts.component.scss
@@ -1216,3 +1216,23 @@
     .stats-counters { grid-template-columns: repeat(2, 1fr); }
     .stats-two-col  { grid-template-columns: 1fr; }
 }
+
+::ng-deep .transcript-annotation {
+    border-radius: 2px;
+    cursor: default;
+    padding: 0 1px;
+}
+
+::ng-deep .transcript-annotation--unit {
+    background-color: rgba(33, 150, 243, 0.15);
+    border-bottom: 2px solid #2196f3;
+}
+
+::ng-deep .transcript-annotation--channel {
+    background-color: rgba(76, 175, 80, 0.15);
+    border-bottom: 2px solid #4caf50;
+}
+
+::ng-deep .transcript-annotation--fuzzy {
+    border-bottom-style: dashed;
+}

--- a/client/src/app/components/rdio-scanner/alerts/alerts.component.ts
+++ b/client/src/app/components/rdio-scanner/alerts/alerts.component.ts
@@ -25,6 +25,7 @@ import { RdioScannerAlert, RdioScannerCall, RdioScannerService, RdioScannerTrans
 import { AlertsService } from './alerts.service';
 import { AlertSoundService } from '../alert-sound.service';
 import { SettingsService } from '../settings/settings.service';
+import { TranscriptAnnotation, renderAnnotatedTranscript } from '../transcript-utils';
 
 /** Main board hosts separate tabs; each instance uses one mode. */
 export type RdioScannerAlertsPanelMode = 'alertsAndPreferences' | 'transcripts' | 'stats';
@@ -297,6 +298,10 @@ export class RdioScannerAlertsComponent implements OnDestroy, OnInit {
         }
         const regex = new RegExp(`(${search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
         return text.replace(regex, '<mark>$1</mark>');
+    }
+
+    renderTranscript(transcript: string, annotations?: TranscriptAnnotation[], search?: string): string {
+        return renderAnnotatedTranscript(transcript, annotations, search);
     }
 
     ngOnDestroy(): void {

--- a/client/src/app/components/rdio-scanner/main/main.component.html
+++ b/client/src/app/components/rdio-scanner/main/main.component.html
@@ -191,7 +191,8 @@
                     </table>
                     <div class="now-playing-transcript" *ngIf="call && isTranscriptionEnabled && call.transcript">
                         <span class="now-playing-transcript-label">Transcript</span>
-                        <p class="now-playing-transcript-text">{{ call.transcript }}</p>
+                        <p class="now-playing-transcript-text"
+                           [innerHTML]="renderTranscript(call.transcript, call.transcriptAnnotations)"></p>
                     </div>
                 </div>
             </div>
@@ -268,7 +269,8 @@
                                 </div>
                                 <div class="transcript-block" *ngIf="isTranscriptionEnabled && dc.transcript">
                                     <div class="detail-k">Transcript</div>
-                                    <p class="transcript-body">{{ dc.transcript }}</p>
+                                    <p class="transcript-body"
+                                       [innerHTML]="renderTranscript(dc.transcript, dc.transcriptAnnotations)"></p>
                                 </div>
                             </div>
                             </ng-container>

--- a/client/src/app/components/rdio-scanner/main/main.component.scss
+++ b/client/src/app/components/rdio-scanner/main/main.component.scss
@@ -2155,3 +2155,23 @@
     color: #64b5f6;
   }
 }
+
+::ng-deep .transcript-annotation {
+  border-radius: 2px;
+  cursor: default;
+  padding: 0 1px;
+}
+
+::ng-deep .transcript-annotation--unit {
+  background-color: rgba(33, 150, 243, 0.15);
+  border-bottom: 2px solid #2196f3;
+}
+
+::ng-deep .transcript-annotation--channel {
+  background-color: rgba(76, 175, 80, 0.15);
+  border-bottom: 2px solid #4caf50;
+}
+
+::ng-deep .transcript-annotation--fuzzy {
+  border-bottom-style: dashed;
+}

--- a/client/src/app/components/rdio-scanner/main/main.component.ts
+++ b/client/src/app/components/rdio-scanner/main/main.component.ts
@@ -35,6 +35,7 @@ import {
     RdioScannerLivefeedMode,
 } from '../rdio-scanner';
 import { RdioScannerService } from '../rdio-scanner.service';
+import { TranscriptAnnotation, renderAnnotatedTranscript } from '../transcript-utils';
 import { TagColorService } from '../tag-color.service';
 import { RdioScannerSupportComponent } from './support/support.component';
 import { SettingsService } from '../settings/settings.service';
@@ -146,6 +147,10 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
     get isTranscriptionEnabled(): boolean {
         // Check if transcriptions are enabled in the config
         return this.config?.options?.transcriptionEnabled || false;
+    }
+
+    renderTranscript(transcript: string, annotations?: TranscriptAnnotation[]): string {
+        return renderAnnotatedTranscript(transcript, annotations);
     }
 
     get showScanningAnimation(): boolean {

--- a/client/src/app/components/rdio-scanner/rdio-scanner.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.ts
@@ -71,6 +71,7 @@ export interface RdioScannerCall {
     transcript?: string;
     transcriptConfidence?: number;
     transcriptionStatus?: string;
+    transcriptAnnotations?: import('./transcript-utils').TranscriptAnnotation[];
 }
 
 export interface RdioScannerToneSequence {
@@ -112,6 +113,7 @@ export interface RdioScannerAlert {
     transcript?: string;
     alertSummary?: string;
     transcriptionStatus?: string;
+    transcriptAnnotations?: import('./transcript-utils').TranscriptAnnotation[];
     createdAt: number;
     systemLabel?: string;
     talkgroupLabel?: string;
@@ -131,6 +133,7 @@ export interface RdioScannerTranscript {
     systemLabel?: string;
     talkgroupLabel?: string;
     talkgroupName?: string;
+    transcriptAnnotations?: import('./transcript-utils').TranscriptAnnotation[];
 }
 
 export interface RdioScannerAlertPreference {

--- a/client/src/app/components/rdio-scanner/transcript-utils.ts
+++ b/client/src/app/components/rdio-scanner/transcript-utils.ts
@@ -1,0 +1,92 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Carter Carling <carter@cartercarling.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+export interface TranscriptAnnotation {
+    type: 'unit' | 'channel';
+    text: string;
+    /** Unicode code-point (rune) offset in the corrected transcript string (inclusive). Compatible with JS string character indices. */
+    start: number;
+    /** Unicode code-point (rune) offset in the corrected transcript string (exclusive). Compatible with JS string character indices. */
+    end: number;
+    prefix?: string;
+    apparatus?: string;
+    number?: string;
+    dispatch?: string;
+    separator?: string;
+    channel?: string;
+    fuzzy: boolean;
+}
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function applySearchHighlight(s: string, search: string): string {
+    if (!search || !s) return s;
+    const re = new RegExp(`(${search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+    return s.replace(re, '<mark>$1</mark>');
+}
+
+/**
+ * Renders a transcript string as HTML, wrapping recognized units and channels
+ * in styled <span> elements using the byte offsets from transcriptAnnotations.
+ * Optionally applies search-term highlighting to plain-text segments.
+ *
+ * Safe to call with no annotations — falls back to escaped plain text with
+ * optional search highlighting (identical to the old behavior).
+ */
+export function renderAnnotatedTranscript(
+    transcript: string,
+    annotations?: TranscriptAnnotation[],
+    searchText?: string,
+): string {
+    if (!transcript) return '';
+
+    if (!annotations || annotations.length === 0) {
+        return applySearchHighlight(escapeHtml(transcript), searchText || '');
+    }
+
+    let result = '';
+    let lastEnd = 0;
+
+    for (const ann of annotations) {
+        // Plain text before this annotation — apply search highlight
+        if (ann.start > lastEnd) {
+            result += applySearchHighlight(escapeHtml(transcript.slice(lastEnd, ann.start)), searchText || '');
+        }
+
+        const cssClass = `transcript-annotation transcript-annotation--${ann.type}` +
+            (ann.fuzzy ? ' transcript-annotation--fuzzy' : '');
+
+        result += `<span class="${cssClass}">${escapeHtml(ann.text)}</span>`;
+
+        lastEnd = ann.end;
+    }
+
+    // Remaining plain text after the last annotation
+    if (lastEnd < transcript.length) {
+        result += applySearchHighlight(escapeHtml(transcript.slice(lastEnd)), searchText || '');
+    }
+
+    return result;
+}

--- a/server/admin.go
+++ b/server/admin.go
@@ -1455,13 +1455,13 @@ func (admin *Admin) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 					if err != nil {
 						logError(err)
 					} else {
-					// Restart transcription queue with updated settings
-					admin.Controller.RestartTranscriptionQueue()
+						// Restart transcription queue with updated settings
+						admin.Controller.RestartTranscriptionQueue()
 
-					// Restart no-audio monitoring in case health alert settings changed
-					go admin.Controller.StartNoAudioMonitoringForAllSystems()
+						// Restart no-audio monitoring in case health alert settings changed
+						go admin.Controller.StartNoAudioMonitoringForAllSystems()
 
-					// If audio encryption is enabled and we don't have a key yet
+						// If audio encryption is enabled and we don't have a key yet
 						// (or it was just enabled), fetch the key + client token from
 						// the relay server without requiring a server restart.
 						if admin.Controller.Options.AudioEncryptionEnabled &&
@@ -1769,22 +1769,22 @@ func (admin *Admin) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 			case []any:
 				// Only delete ALL existing users for full imports, not regular saves
 				if isFullImport {
-				allUsers := admin.Controller.Users.GetAllUsers()
-				for _, existingUser := range allUsers {
-					// Delete dependent rows first (FK constraints have no CASCADE after migration)
-					admin.Controller.Database.Sql.Exec(`DELETE FROM "userAlertPreferences" WHERE "userId" = $1`, existingUser.Id)
-					admin.Controller.Database.Sql.Exec(`DELETE FROM "deviceTokens" WHERE "userId" = $1`, existingUser.Id)
-					// Now safe to delete the user
-					_, err := admin.Controller.Database.Sql.Exec(`DELETE FROM "users" WHERE "userId" = $1`, existingUser.Id)
-					if err != nil {
-						logError(fmt.Errorf("failed to delete user %s from database during import: %v", existingUser.Email, err))
-					} else {
-						// Remove from in-memory map
-						if err := admin.Controller.Users.Remove(existingUser.Id); err != nil {
-							logError(fmt.Errorf("failed to remove user %s from memory during import: %v", existingUser.Email, err))
+					allUsers := admin.Controller.Users.GetAllUsers()
+					for _, existingUser := range allUsers {
+						// Delete dependent rows first (FK constraints have no CASCADE after migration)
+						admin.Controller.Database.Sql.Exec(`DELETE FROM "userAlertPreferences" WHERE "userId" = $1`, existingUser.Id)
+						admin.Controller.Database.Sql.Exec(`DELETE FROM "deviceTokens" WHERE "userId" = $1`, existingUser.Id)
+						// Now safe to delete the user
+						_, err := admin.Controller.Database.Sql.Exec(`DELETE FROM "users" WHERE "userId" = $1`, existingUser.Id)
+						if err != nil {
+							logError(fmt.Errorf("failed to delete user %s from database during import: %v", existingUser.Email, err))
+						} else {
+							// Remove from in-memory map
+							if err := admin.Controller.Users.Remove(existingUser.Id); err != nil {
+								logError(fmt.Errorf("failed to remove user %s from memory during import: %v", existingUser.Email, err))
+							}
 						}
 					}
-				}
 				}
 
 				// Now create/update users from import
@@ -2081,21 +2081,21 @@ func (admin *Admin) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 							}
 						}
 
-					// Use empty slices instead of nil so we always store "[]" not "null"
-					if keywords == nil {
-						keywords = []string{}
-					}
-					if keywordListIds == nil {
-						keywordListIds = []int{}
-					}
-					if toneSetIds == nil {
-						toneSetIds = []string{}
-					}
-					keywordsJson, _ := json.Marshal(keywords)
-					keywordListIdsJson, _ := json.Marshal(keywordListIds)
-					toneSetIdsJson, _ := json.Marshal(toneSetIds)
+						// Use empty slices instead of nil so we always store "[]" not "null"
+						if keywords == nil {
+							keywords = []string{}
+						}
+						if keywordListIds == nil {
+							keywordListIds = []int{}
+						}
+						if toneSetIds == nil {
+							toneSetIds = []string{}
+						}
+						keywordsJson, _ := json.Marshal(keywords)
+						keywordListIdsJson, _ := json.Marshal(keywordListIds)
+						toneSetIdsJson, _ := json.Marshal(toneSetIds)
 
-					// Insert user alert preference using parameterized queries
+						// Insert user alert preference using parameterized queries
 						if admin.Controller.Database.Config.DbType == DbTypePostgresql {
 							query := `INSERT INTO "userAlertPreferences" ("userId", "systemId", "talkgroupId", "alertEnabled", "toneAlerts", "keywordAlerts", "keywords", "keywordListIds", "toneSetIds") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 							if _, err := admin.Controller.Database.Sql.Exec(query, actualUserId, systemId, talkgroupId, alertEnabled, toneAlerts, keywordAlerts, string(keywordsJson), string(keywordListIdsJson), string(toneSetIdsJson)); err != nil {
@@ -2424,7 +2424,7 @@ func (admin *Admin) GetConfig() map[string]any {
 
 	// Get all user alert preferences from cache for export
 	userAlertPrefList := make([]map[string]any, 0)
-	
+
 	// We need to query the database for this as we don't have a method to get ALL preferences
 	// across ALL users from cache. This is acceptable as it's only for admin config export.
 	// Alternative: Could add GetAllPreferences() to cache, but export is rare operation.
@@ -6200,4 +6200,46 @@ func (api *Api) TestPagerAlertHandler(w http.ResponseWriter, r *http.Request) {
 		"talkgroupLabel": talkgroupLabel,
 		"tokensSent":     len(tokens),
 	})
+}
+
+// TranscriptParserHandler handles GET and PUT for the transcript parser config.
+//
+// GET  /api/admin/transcript-parser — returns the current TranscriptConfig as JSON.
+// PUT  /api/admin/transcript-parser — replaces the config, rebuilds the active parser.
+func (admin *Admin) TranscriptParserHandler(w http.ResponseWriter, r *http.Request) {
+	t := admin.GetAuthorization(r)
+	if !admin.ValidateToken(t) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.Method {
+	case http.MethodGet:
+		json.NewEncoder(w).Encode(admin.Controller.Options.TranscriptParserConfig)
+
+	case http.MethodPut:
+		var cfg TranscriptConfig
+		if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+			return
+		}
+
+		admin.Controller.Options.TranscriptParserConfig = cfg
+
+		if err := admin.Controller.Options.Write(admin.Controller.Database); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("failed to save config: %v", err)})
+			return
+		}
+
+		admin.Controller.rebuildTranscriptParser()
+
+		json.NewEncoder(w).Encode(map[string]bool{"success": true})
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
 }

--- a/server/api.go
+++ b/server/api.go
@@ -66,17 +66,17 @@ func (c *signupVerificationCache) Set(email, code string, expiryTime int64) {
 func (c *signupVerificationCache) Get(email string) (string, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	
+
 	code, exists := c.codes[email]
 	if !exists {
 		return "", false
 	}
-	
+
 	// Check if expired
 	if expiry, ok := c.expiry[email]; ok && time.Now().Unix() > expiry {
 		return "", false
 	}
-	
+
 	return code, true
 }
 
@@ -540,16 +540,16 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var request struct {
-		Email              string `json:"email"`
-		Password           string `json:"password"`
-		FirstName          string `json:"firstName"`
-		LastName           string `json:"lastName"`
-		ZipCode            string `json:"zipCode"`
-		RegistrationCode   string `json:"registrationCode"` // Deprecated: use accessCode
-		InvitationCode     string `json:"invitationCode"`   // Deprecated: use accessCode
-		AccessCode         string `json:"accessCode"`       // Unified field for both invitation and registration codes
-		TurnstileToken     string `json:"turnstile_token"`
-		VerificationCode   string `json:"verificationCode"` // Email verification code (if emailVerificationRequired)
+		Email            string `json:"email"`
+		Password         string `json:"password"`
+		FirstName        string `json:"firstName"`
+		LastName         string `json:"lastName"`
+		ZipCode          string `json:"zipCode"`
+		RegistrationCode string `json:"registrationCode"` // Deprecated: use accessCode
+		InvitationCode   string `json:"invitationCode"`   // Deprecated: use accessCode
+		AccessCode       string `json:"accessCode"`       // Unified field for both invitation and registration codes
+		TurnstileToken   string `json:"turnstile_token"`
+		VerificationCode string `json:"verificationCode"` // Email verification code (if emailVerificationRequired)
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
@@ -2837,8 +2837,16 @@ func (api *Api) AlertsHandler(w http.ResponseWriter, r *http.Request) {
 			if talkgroupName.Valid {
 				alertMap["talkgroupName"] = talkgroupName.String
 			}
-			if callTranscript.Valid {
-				alertMap["transcript"] = callTranscript.String
+			if callTranscript.Valid && callTranscript.String != "" {
+				t := callTranscript.String
+				if p := activeTranscriptParser.Load(); p != nil {
+					corrected, annotations := p.AnnotateTranscript(t)
+					t = corrected
+					if len(annotations) > 0 {
+						alertMap["transcriptAnnotations"] = annotations
+					}
+				}
+				alertMap["transcript"] = t
 			}
 			if callTranscriptionStatus.Valid {
 				alertMap["transcriptionStatus"] = callTranscriptionStatus.String
@@ -3306,8 +3314,18 @@ func (api *Api) TranscriptsHandler(w http.ResponseWriter, r *http.Request) {
 			"callId":              callId,
 			"systemId":            sysId,
 			"talkgroupId":         tgId,
-			"transcript":          transcript.String,
 			"transcriptionStatus": transcriptionStatus.String,
+		}
+		if transcript.Valid && transcript.String != "" {
+			t := transcript.String
+			if p := activeTranscriptParser.Load(); p != nil {
+				corrected, annotations := p.AnnotateTranscript(t)
+				t = corrected
+				if len(annotations) > 0 {
+					entry["transcriptAnnotations"] = annotations
+				}
+			}
+			entry["transcript"] = t
 		}
 		if callTimestamp.Valid {
 			entry["timestamp"] = callTimestamp.Int64
@@ -3357,7 +3375,7 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 	case http.MethodGet:
 		// Get preferences from cache
 		cachedPrefs := api.Controller.PreferencesCache.GetUserPreferences(client.User.Id)
-		
+
 		preferences := []map[string]any{}
 		for _, pref := range cachedPrefs {
 			// Look up systemRef and talkgroupRef from in-memory Systems
@@ -3369,21 +3387,21 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 
-		prefMap := map[string]any{
-			"userId":               pref.UserId,
-			"systemId":             pref.SystemId,
-			"talkgroupId":          pref.TalkgroupId,
-			"alertEnabled":         pref.AlertEnabled,
-			"toneAlerts":           pref.ToneAlerts,
-			"keywordAlerts":        pref.KeywordAlerts,
-			"keywords":             pref.Keywords,
-			"keywordListIds":       pref.KeywordListIds,
-			"toneSetIds":           pref.ToneSetIds,
-			"notificationSound":    pref.NotificationSound,
-			"toneSetSounds":        pref.ToneSetSounds,
-			"pagerAlert":           pref.PagerAlert,
-			"toneSetPagerAlerts":   pref.ToneSetPagerAlerts,
-		}
+			prefMap := map[string]any{
+				"userId":             pref.UserId,
+				"systemId":           pref.SystemId,
+				"talkgroupId":        pref.TalkgroupId,
+				"alertEnabled":       pref.AlertEnabled,
+				"toneAlerts":         pref.ToneAlerts,
+				"keywordAlerts":      pref.KeywordAlerts,
+				"keywords":           pref.Keywords,
+				"keywordListIds":     pref.KeywordListIds,
+				"toneSetIds":         pref.ToneSetIds,
+				"notificationSound":  pref.NotificationSound,
+				"toneSetSounds":      pref.ToneSetSounds,
+				"pagerAlert":         pref.PagerAlert,
+				"toneSetPagerAlerts": pref.ToneSetPagerAlerts,
+			}
 
 			// Include systemRef and talkgroupRef for frontend matching
 			if systemRef > 0 {
@@ -3419,21 +3437,21 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 		defer tx.Rollback()
 
 		for _, pref := range preferences {
-		var (
-			requestSystem      uint64
-			requestTg          uint64
-			systemId           uint64
-			alertEnabled       bool
-			toneAlerts         bool = true
-			keywordAlerts      bool = true
-			keywords           []string
-			keywordListIds     []uint64
-			toneSetIds         []string
-			notificationSound  string
-			toneSetSounds      map[string]string
-			pagerAlert         bool
-			toneSetPagerAlerts map[string]bool
-		)
+			var (
+				requestSystem      uint64
+				requestTg          uint64
+				systemId           uint64
+				alertEnabled       bool
+				toneAlerts         bool = true
+				keywordAlerts      bool = true
+				keywords           []string
+				keywordListIds     []uint64
+				toneSetIds         []string
+				notificationSound  string
+				toneSetSounds      map[string]string
+				pagerAlert         bool
+				toneSetPagerAlerts map[string]bool
+			)
 
 			// Accept either systemRef or systemId field names — prefer systemRef
 			// since the resolution logic queries by systemRef column first,
@@ -3546,28 +3564,28 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 				toneAlerts = false
 			}
 
-		keywordsJson, _ := json.Marshal(keywords)
-		keywordListIdsJson, _ := json.Marshal(keywordListIds)
-		toneSetIdsJson, _ := json.Marshal(toneSetIds)
-		toneSetSoundsJson, _ := json.Marshal(toneSetSounds)
-		toneSetPagerAlertsJson, _ := json.Marshal(toneSetPagerAlerts)
+			keywordsJson, _ := json.Marshal(keywords)
+			keywordListIdsJson, _ := json.Marshal(keywordListIds)
+			toneSetIdsJson, _ := json.Marshal(toneSetIds)
+			toneSetSoundsJson, _ := json.Marshal(toneSetSounds)
+			toneSetPagerAlertsJson, _ := json.Marshal(toneSetPagerAlerts)
 
-		// Ensure we never store "null" for arrays/objects
-		if string(keywordsJson) == "null" {
-			keywordsJson = []byte("[]")
-		}
-		if string(keywordListIdsJson) == "null" {
-			keywordListIdsJson = []byte("[]")
-		}
-		if string(toneSetIdsJson) == "null" {
-			toneSetIdsJson = []byte("[]")
-		}
-		if string(toneSetSoundsJson) == "null" {
-			toneSetSoundsJson = []byte("{}")
-		}
-		if string(toneSetPagerAlertsJson) == "null" {
-			toneSetPagerAlertsJson = []byte("{}")
-		}
+			// Ensure we never store "null" for arrays/objects
+			if string(keywordsJson) == "null" {
+				keywordsJson = []byte("[]")
+			}
+			if string(keywordListIdsJson) == "null" {
+				keywordListIdsJson = []byte("[]")
+			}
+			if string(toneSetIdsJson) == "null" {
+				toneSetIdsJson = []byte("[]")
+			}
+			if string(toneSetSoundsJson) == "null" {
+				toneSetSoundsJson = []byte("{}")
+			}
+			if string(toneSetPagerAlertsJson) == "null" {
+				toneSetPagerAlertsJson = []byte("{}")
+			}
 
 			// DEBUG: Log tone set preferences being saved
 			if toneAlerts {
@@ -3581,10 +3599,10 @@ func (api *Api) AlertPreferencesHandler(w http.ResponseWriter, r *http.Request) 
 				api.Controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("💾 [TONE SET DEBUG] Saving preference for user %d, system %d, talkgroup %d: toneAlerts=false (only keyword alerts)", client.User.Id, systemId, dbTalkgroupId))
 			}
 
-		// Upsert preference using verified database talkgroupId
-		query := fmt.Sprintf(`INSERT INTO "userAlertPreferences" ("userId", "systemId", "talkgroupId", "alertEnabled", "toneAlerts", "keywordAlerts", "keywords", "keywordListIds", "toneSetIds", "notificationSound", "toneSetSounds", "pagerAlert", "toneSetPagerAlerts") VALUES (%d, %d, %d, %t, %t, %t, $1, $2, $3, $4, $5, %t, $6) ON CONFLICT ("userId", "systemId", "talkgroupId") DO UPDATE SET "alertEnabled" = %t, "toneAlerts" = %t, "keywordAlerts" = %t, "keywords" = $1, "keywordListIds" = $2, "toneSetIds" = $3, "notificationSound" = $4, "toneSetSounds" = $5, "pagerAlert" = %t, "toneSetPagerAlerts" = $6`, client.User.Id, systemId, dbTalkgroupId, alertEnabled, toneAlerts, keywordAlerts, pagerAlert, alertEnabled, toneAlerts, keywordAlerts, pagerAlert)
+			// Upsert preference using verified database talkgroupId
+			query := fmt.Sprintf(`INSERT INTO "userAlertPreferences" ("userId", "systemId", "talkgroupId", "alertEnabled", "toneAlerts", "keywordAlerts", "keywords", "keywordListIds", "toneSetIds", "notificationSound", "toneSetSounds", "pagerAlert", "toneSetPagerAlerts") VALUES (%d, %d, %d, %t, %t, %t, $1, $2, $3, $4, $5, %t, $6) ON CONFLICT ("userId", "systemId", "talkgroupId") DO UPDATE SET "alertEnabled" = %t, "toneAlerts" = %t, "keywordAlerts" = %t, "keywords" = $1, "keywordListIds" = $2, "toneSetIds" = $3, "notificationSound" = $4, "toneSetSounds" = $5, "pagerAlert" = %t, "toneSetPagerAlerts" = $6`, client.User.Id, systemId, dbTalkgroupId, alertEnabled, toneAlerts, keywordAlerts, pagerAlert, alertEnabled, toneAlerts, keywordAlerts, pagerAlert)
 
-		if _, err := tx.Exec(query, string(keywordsJson), string(keywordListIdsJson), string(toneSetIdsJson), notificationSound, string(toneSetSoundsJson), string(toneSetPagerAlertsJson)); err != nil {
+			if _, err := tx.Exec(query, string(keywordsJson), string(keywordListIdsJson), string(toneSetIdsJson), notificationSound, string(toneSetSoundsJson), string(toneSetPagerAlertsJson)); err != nil {
 				api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to update preference: %v", err))
 				return
 			}
@@ -3627,7 +3645,7 @@ func (api *Api) KeywordListsHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		// Get all keyword lists from cache
 		cachedLists := api.Controller.KeywordListsCache.GetAllLists()
-		
+
 		lists := []map[string]any{}
 		for _, list := range cachedLists {
 			lists = append(lists, map[string]any{
@@ -3693,12 +3711,12 @@ func (api *Api) KeywordListsHandler(w http.ResponseWriter, r *http.Request) {
 			api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create keyword list: %v", err))
 			return
 		}
-		
+
 		// Reload keyword lists cache after creation
 		if err := api.Controller.KeywordListsCache.Read(api.Controller.Database); err != nil {
 			api.Controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("failed to reload keyword lists cache after create: %v", err))
 		}
-		
+
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(fmt.Sprintf(`{"id": %d, "success": true}`, listId)))
 

--- a/server/call.go
+++ b/server/call.go
@@ -173,9 +173,17 @@ func (call *Call) MarshalJSON() ([]byte, error) {
 	}
 
 	if call.Transcript != "" {
-		callMap["transcript"] = call.Transcript
+		transcript := call.Transcript
 		callMap["transcriptConfidence"] = call.TranscriptConfidence
 		callMap["transcriptionStatus"] = call.TranscriptionStatus
+		if p := activeTranscriptParser.Load(); p != nil {
+			corrected, annotations := p.AnnotateTranscript(call.Transcript)
+			transcript = corrected
+			if len(annotations) > 0 {
+				callMap["transcriptAnnotations"] = annotations
+			}
+		}
+		callMap["transcript"] = transcript
 	}
 	if call.AlertSummary != "" {
 		callMap["alertSummary"] = call.AlertSummary
@@ -301,9 +309,17 @@ func (call *Call) MarshalJSONWithEncryption(key []byte) ([]byte, error) {
 		callMap["toneSequence"] = call.ToneSequence
 	}
 	if call.Transcript != "" {
-		callMap["transcript"] = call.Transcript
+		transcript := call.Transcript
 		callMap["transcriptConfidence"] = call.TranscriptConfidence
 		callMap["transcriptionStatus"] = call.TranscriptionStatus
+		if p := activeTranscriptParser.Load(); p != nil {
+			corrected, annotations := p.AnnotateTranscript(call.Transcript)
+			transcript = corrected
+			if len(annotations) > 0 {
+				callMap["transcriptAnnotations"] = annotations
+			}
+		}
+		callMap["transcript"] = transcript
 	}
 	if call.AlertSummary != "" {
 		callMap["alertSummary"] = call.AlertSummary
@@ -397,8 +413,6 @@ const audioFingerprintWindow = 120 * time.Second
 // duplicate detection when the admin has not configured DuplicateTimestampWindow.
 const defaultTimestampFallbackWindow = 800 * time.Millisecond
 
-
-
 // CheckDuplicateByHash queries the DB for any call on the same system+talkgroup
 // whose PCM content hash matches this call's hash. A hash match means the decoded
 // audio samples are bit-identical — a guaranteed duplicate regardless of how far
@@ -476,7 +490,6 @@ func (calls *Calls) CheckDuplicateByTimestamp(call *Call, db *Database, windowMs
 
 	return false, nil
 }
-
 
 func (calls *Calls) GetCall(id uint64) (*Call, error) {
 	var (
@@ -618,12 +631,12 @@ func (calls *Calls) GetCall(id uint64) (*Call, error) {
 
 // GetCallsBulk fetches multiple calls in 3 queries instead of N×2 round-trips.
 //
-//  Query 1 — metadata + patches (no audio blob; avoids GROUP BY on blobs):
-//            callId, timestamp, patches, systemId, talkgroupId, frequency,
-//            toneSequence, hasTones, transcript, transcriptConfidence,
-//            transcriptionStatus, alertSummary
-//  Query 2 — audio bytes + filenames: callId, audio, audioFilename, audioMime, siteRef
-//  Query 3 — units:                   callId, offset, unitRef, label
+//	Query 1 — metadata + patches (no audio blob; avoids GROUP BY on blobs):
+//	          callId, timestamp, patches, systemId, talkgroupId, frequency,
+//	          toneSequence, hasTones, transcript, transcriptConfidence,
+//	          transcriptionStatus, alertSummary
+//	Query 2 — audio bytes + filenames: callId, audio, audioFilename, audioMime, siteRef
+//	Query 3 — units:                   callId, offset, unitRef, label
 //
 // Any IDs currently in the delay queue are silently skipped.
 func (calls *Calls) GetCallsBulk(ids []uint64) []*Call {
@@ -740,7 +753,7 @@ func (calls *Calls) GetCallsBulk(ids []uint64) []*Call {
 
 	// --- Query 2: audio blobs ---
 	audioRows, err := calls.controller.Database.Sql.Query(
-		`SELECT "callId", "audio", "audioFilename", "audioMime", "siteRef" FROM "calls" WHERE "callId" IN (`+inClause+`)`)
+		`SELECT "callId", "audio", "audioFilename", "audioMime", "siteRef" FROM "calls" WHERE "callId" IN (` + inClause + `)`)
 	if err == nil {
 		defer audioRows.Close()
 		for audioRows.Next() {
@@ -760,7 +773,7 @@ func (calls *Calls) GetCallsBulk(ids []uint64) []*Call {
 
 	// --- Query 3: units ---
 	unitRows, err := calls.controller.Database.Sql.Query(
-		`SELECT "callId", "offset", "unitRef", COALESCE("label", '') FROM "callUnits" WHERE "callId" IN (`+inClause+`) ORDER BY "callId", "offset" ASC`)
+		`SELECT "callId", "offset", "unitRef", COALESCE("label", '') FROM "callUnits" WHERE "callId" IN (` + inClause + `) ORDER BY "callId", "offset" ASC`)
 	if err == nil {
 		defer unitRows.Close()
 		for unitRows.Next() {

--- a/server/controller.go
+++ b/server/controller.go
@@ -71,18 +71,18 @@ type Controller struct {
 	HallucinationDetector            *HallucinationDetector
 	CentralManagement                *CentralManagementService
 	// Performance caches
-	PreferencesCache                 *PreferencesCache
-	KeywordListsCache                *KeywordListsCache
-	IdLookupsCache                   *IdLookupsCache
-	RecentAlertsCache                *RecentAlertsCache
-	DedupCache                       *DedupCache
-	Register                         chan *Client
-	Unregister                       chan *Client
-	Ingest                           chan *Call
-	running                          bool
-	workerCancel                     context.CancelFunc // Function to cancel worker context
-	workersWg                        sync.WaitGroup     // WaitGroup to track worker goroutines
-	workerStats                      struct {
+	PreferencesCache  *PreferencesCache
+	KeywordListsCache *KeywordListsCache
+	IdLookupsCache    *IdLookupsCache
+	RecentAlertsCache *RecentAlertsCache
+	DedupCache        *DedupCache
+	Register          chan *Client
+	Unregister        chan *Client
+	Ingest            chan *Call
+	running           bool
+	workerCancel      context.CancelFunc // Function to cancel worker context
+	workersWg         sync.WaitGroup     // WaitGroup to track worker goroutines
+	workerStats       struct {
 		sync.Mutex
 		activeWorkers  int
 		totalCalls     int64
@@ -505,13 +505,13 @@ func (controller *Controller) IngestCall(call *Call) {
 			}
 
 			talkgroup = &Talkgroup{
-				GroupIds:        []uint64{groupId},
-				Label:           fmt.Sprintf("%d", talkgroupId),
-				Name:            fmt.Sprintf("%d", talkgroupId),
-				TalkgroupRef:    talkgroupId,
-				TagId:           tagId,
-				Order:           maxOrder + 1, // Assign order at the end of the list
-				AlertsEnabled:   system.AutoPopulateAlertsEnabled,
+				GroupIds:      []uint64{groupId},
+				Label:         fmt.Sprintf("%d", talkgroupId),
+				Name:          fmt.Sprintf("%d", talkgroupId),
+				TalkgroupRef:  talkgroupId,
+				TagId:         tagId,
+				Order:         maxOrder + 1, // Assign order at the end of the list
+				AlertsEnabled: system.AutoPopulateAlertsEnabled,
 			}
 
 			// Update label and name if provided (v6 style)
@@ -863,7 +863,6 @@ func (controller *Controller) processCallAfterDuplicateCheck(call *Call) {
 				})
 			}
 		}
-
 
 		if !call.IsDuplicate {
 			// IMMEDIATE: Emit call to clients (users can play NOW - zero delay)
@@ -3056,6 +3055,9 @@ func (controller *Controller) Start() error {
 		controller.Logs.LogEvent(LogLevelInfo, "transcription is disabled in config")
 	}
 
+	// Build the transcript parser from saved config (no-op if config is empty)
+	controller.rebuildTranscriptParser()
+
 	// Initialize Hydra transcription retrieval queue if enabled
 	if controller.Options.HydraTranscriptionEnabled && controller.Options.HydraAPIKey != "" {
 		controller.HydraTranscriptionRetrievalQueue = NewHydraTranscriptionRetrievalQueue(controller)
@@ -3177,6 +3179,13 @@ func (controller *Controller) Start() error {
 	controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf("startup: server ready in %s", time.Since(startupStart).Round(time.Millisecond)))
 
 	return nil
+}
+
+// rebuildTranscriptParser compiles a new TranscriptParser from the current
+// Options.TranscriptParserConfig and stores it as the active parser.
+func (controller *Controller) rebuildTranscriptParser() {
+	p := NewTranscriptParser(controller.Options.TranscriptParserConfig)
+	activeTranscriptParser.Store(p)
 }
 
 // RestartTranscriptionQueue restarts the transcription queue with updated settings

--- a/server/main.go
+++ b/server/main.go
@@ -236,6 +236,7 @@ func main() {
 
 	http.HandleFunc("/api/admin/transcription-failures", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.TranscriptionFailuresHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/transcription-failure-threshold", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.TranscriptionFailureThresholdHandler)).ServeHTTP)
+	http.HandleFunc("/api/admin/transcript-parser", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.TranscriptParserHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/tone-detection-issue-threshold", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.ToneDetectionIssueThresholdHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/alert-retention-days", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.AlertRetentionDaysHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/no-audio-threshold-minutes", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.NoAudioThresholdMinutesHandler)).ServeHTTP)

--- a/server/options.go
+++ b/server/options.go
@@ -87,6 +87,7 @@ type Options struct {
 	TranscriptionConfig           TranscriptionConfig `json:"transcriptionConfig"`
 	TranscriptionEnhancement      bool                `json:"transcriptionEnhancement"`
 	TranscriptionFailureThreshold uint                `json:"transcriptionFailureThreshold"`
+	TranscriptParserConfig        TranscriptConfig    `json:"transcriptParserConfig"`
 	ToneDetectionIssueThreshold   uint                `json:"toneDetectionIssueThreshold"`
 	AlertRetentionDays            uint                `json:"alertRetentionDays"`
 	NoAudioThresholdMinutes       uint                `json:"noAudioThresholdMinutes"`
@@ -118,10 +119,10 @@ type Options struct {
 	AudioEncryptionEnabled bool `json:"audioEncryptionEnabled"`
 	// Download rate limiting — applied per WebSocket connection.
 	// Set MaxDownloadsPerWindow to 0 to disable.
-	MaxDownloadsPerWindow uint `json:"maxDownloadsPerWindow"` // max download requests in the window
-	DownloadWindowMinutes uint `json:"downloadWindowMinutes"` // rolling window size in minutes (1–60)
-	RadioReferenceAPIKey              string `json:"radioReferenceAPIKey"`
-	AdminLocalhostOnly                bool   `json:"adminLocalhostOnly"`
+	MaxDownloadsPerWindow uint   `json:"maxDownloadsPerWindow"` // max download requests in the window
+	DownloadWindowMinutes uint   `json:"downloadWindowMinutes"` // rolling window size in minutes (1–60)
+	RadioReferenceAPIKey  string `json:"radioReferenceAPIKey"`
+	AdminLocalhostOnly    bool   `json:"adminLocalhostOnly"`
 	// When true, the traditional admin password login form is disabled. Admin access is only
 	// possible via system admin user SSO or Central Management one-click login.
 	// Guard: the server refuses to set this if no SystemAdmin user exists.
@@ -1391,6 +1392,11 @@ func (options *Options) Read(db *Database) error {
 			if err := json.Unmarshal([]byte(value.String), &cfg); err == nil {
 				options.TranscriptionConfig = cfg
 			}
+		case "transcriptParserConfig":
+			var cfg TranscriptConfig
+			if err := json.Unmarshal([]byte(value.String), &cfg); err == nil {
+				options.TranscriptParserConfig = cfg
+			}
 		case "transcriptionEnhancement":
 			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
 				switch v := f.(type) {
@@ -1517,35 +1523,35 @@ func (options *Options) Read(db *Database) error {
 					options.RelayServerURL = v
 				}
 			}
-	case "relayServerAPIKey":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case string:
-				options.RelayServerAPIKey = v
+		case "relayServerAPIKey":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case string:
+					options.RelayServerAPIKey = v
+				}
 			}
-		}
-	case "audioEncryptionEnabled":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case bool:
-				options.AudioEncryptionEnabled = v
+		case "audioEncryptionEnabled":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case bool:
+					options.AudioEncryptionEnabled = v
+				}
 			}
-		}
-	case "maxDownloadsPerWindow":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case float64:
-				options.MaxDownloadsPerWindow = uint(v)
+		case "maxDownloadsPerWindow":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case float64:
+					options.MaxDownloadsPerWindow = uint(v)
+				}
 			}
-		}
-	case "downloadWindowMinutes":
-		if err = json.Unmarshal([]byte(value.String), &f); err == nil {
-			switch v := f.(type) {
-			case float64:
-				options.DownloadWindowMinutes = uint(v)
+		case "downloadWindowMinutes":
+			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
+				switch v := f.(type) {
+				case float64:
+					options.DownloadWindowMinutes = uint(v)
+				}
 			}
-		}
-	case "hydraAPIKey":
+		case "hydraAPIKey":
 			if err = json.Unmarshal([]byte(value.String), &f); err == nil {
 				switch v := f.(type) {
 				case string:
@@ -1783,6 +1789,7 @@ func (options *Options) Write(db *Database) error {
 	// Persist entire transcription config as a single JSON blob
 	set("transcriptionConfig", options.TranscriptionConfig)
 	set("transcriptionEnhancement", options.TranscriptionEnhancement)
+	set("transcriptParserConfig", options.TranscriptParserConfig)
 
 	if setErr != nil {
 		tx.Rollback()

--- a/server/transcript_parser.go
+++ b/server/transcript_parser.go
@@ -1,0 +1,877 @@
+// Copyright (C) 2026 Carter Carling <carter@cartercarling.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package main
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+//! Important Note: This parser is optimized for Fire Department dispatches
+
+// FuzzyWord represents a word to match with optional fuzzy tolerance.
+// Fields are exported so configs can be JSON-serialized for database / web UI storage.
+type FuzzyWord struct {
+	Word        string   `json:"word"`
+	MaxDistance uint8    `json:"maxDistance"`
+	Aliases     []string `json:"aliases,omitempty"`
+	// Reject lists preceding words that invalidate a match.
+	// ex: match "RESCUE" but not when preceded by "ELEVATOR" so it doesn't
+	// match "RESCUE 123" in "RESPOND TO ELEVATOR RESCUE, 123 MAIN STREET"
+	Reject []string `json:"reject,omitempty"`
+}
+
+// ChannelShorthand maps an abbreviated label to its canonical dispatch name and
+// optional separator. Each entry generates regexp variants for space, dash, and
+// no separator (e.g. "SF 3", "SF-3", "SF3").
+type ChannelShorthand struct {
+	Label     string `json:"label"`
+	Dispatch  string `json:"dispatch"`
+	Separator string `json:"separator,omitempty"` // e.g. "FIRE", "OPS"; empty if none
+}
+
+// TranscriptConfig holds all configurable word lists for the transcript parser.
+// Store this as JSON in the database and expose it through the admin UI.
+type TranscriptConfig struct {
+	UnitTypes     []FuzzyWord `json:"unitTypes"`
+	UnitPrefixes  []FuzzyWord `json:"unitPrefixes"`
+	DispatchNames []FuzzyWord `json:"dispatchNames"`
+	// ChannelSeparators is the word between a dispatch name and channel number
+	// (e.g. "FIRE", "POLICE", "EMS", "OPS"). When empty the parser matches
+	// {Dispatch} {Number} directly with no separator required.
+	ChannelSeparators []FuzzyWord        `json:"channelSeparators,omitempty"`
+	ChannelShorthands []ChannelShorthand `json:"channelShorthands"`
+	Corrections       []FuzzyWord        `json:"corrections"`
+}
+
+// ParsedUnit is the result of recognizing an apparatus unit in a transcript.
+type ParsedUnit struct {
+	Prefix    string   `json:"prefix"`
+	Apparatus string   `json:"apparatus"`
+	Number    string   `json:"number"`
+	Raw       []string `json:"raw"`
+	Fuzzy     bool     `json:"fuzzy"`
+}
+
+// ParsedChannel is the result of recognizing a dispatch channel in a transcript.
+// Example Channels: "City Fire 2" "VECC Fire 5" "OPS 2"
+type ParsedChannel struct {
+	Dispatch  string   `json:"dispatch"`
+	Separator string   `json:"separator"` // the word between dispatch and number, e.g. "FIRE"
+	Channel   string   `json:"channel"`
+	Raw       []string `json:"raw"`
+	Fuzzy     bool     `json:"fuzzy"`
+}
+
+// Candidate represents a possible fuzzy or exact match at a token position.
+type Candidate struct {
+	match    string
+	distance uint8
+	startIdx int
+	endIdx   int // inclusive
+}
+
+type token struct {
+	text  string
+	index int
+}
+
+type compiledShorthand struct {
+	pattern   *regexp.Regexp
+	dispatch  string
+	separator string
+}
+
+// TranscriptParser holds compiled patterns derived from a TranscriptConfig.
+// Build it once with NewTranscriptParser and rebuild whenever the config changes.
+type TranscriptParser struct {
+	cfg               TranscriptConfig
+	unitPattern       *regexp.Regexp
+	unitHasPrefix     bool // true when unitPattern includes the optional prefix capture group
+	channelPattern    *regexp.Regexp
+	channelHasSep     bool // true when channelPattern includes a separator capture group
+	channelShorthands []compiledShorthand
+}
+
+var tokenPattern = regexp.MustCompile(`[A-Z]+|\d+`)
+
+// NewTranscriptParser compiles all regex patterns from cfg and returns a
+// ready-to-use parser. Call again whenever the config changes.
+func NewTranscriptParser(cfg TranscriptConfig) *TranscriptParser {
+	p := &TranscriptParser{cfg: cfg}
+
+	if len(cfg.UnitTypes) > 0 {
+		types := make([]string, len(cfg.UnitTypes))
+		for i, uw := range cfg.UnitTypes {
+			types[i] = regexp.QuoteMeta(uw.Word)
+		}
+
+		if len(cfg.UnitPrefixes) > 0 {
+			prefixes := make([]string, len(cfg.UnitPrefixes))
+			for i, pw := range cfg.UnitPrefixes {
+				prefixes[i] = regexp.QuoteMeta(pw.Word)
+			}
+			p.unitPattern = regexp.MustCompile(
+				`\b(?:(` + strings.Join(prefixes, "|") + `)\s+)?` +
+					`(` + strings.Join(types, "|") + `)` +
+					`\s+(\d{1,3})\b`,
+			)
+			p.unitHasPrefix = true
+		} else {
+			p.unitPattern = regexp.MustCompile(
+				`\b(` + strings.Join(types, "|") + `)` +
+					`\s+(\d{1,3})\b`,
+			)
+		}
+	}
+
+	if len(cfg.DispatchNames) > 0 {
+		dispatches := make([]string, len(cfg.DispatchNames))
+		for i, d := range cfg.DispatchNames {
+			dispatches[i] = regexp.QuoteMeta(d.Word)
+		}
+
+		if len(cfg.ChannelSeparators) > 0 {
+			seps := make([]string, len(cfg.ChannelSeparators))
+			for i, s := range cfg.ChannelSeparators {
+				seps[i] = regexp.QuoteMeta(s.Word)
+			}
+			// Groups: (dispatch) (separator) (number)
+			p.channelPattern = regexp.MustCompile(
+				`\b(` + strings.Join(dispatches, "|") + `)` +
+					`\s+(` + strings.Join(seps, "|") + `)` +
+					`\s+(\d{1,2})\b`,
+			)
+			p.channelHasSep = true
+		} else {
+			// No separator configured — match {Dispatch} {Number} directly.
+			// Groups: (dispatch) (number)
+			p.channelPattern = regexp.MustCompile(
+				`\b(` + strings.Join(dispatches, "|") + `)` +
+					`\s+(\d{1,2})\b`,
+			)
+		}
+	}
+
+	for _, def := range cfg.ChannelShorthands {
+		escaped := regexp.QuoteMeta(def.Label)
+		p.channelShorthands = append(p.channelShorthands,
+			compiledShorthand{pattern: regexp.MustCompile(`\b` + escaped + `\s+(\d{1,2})\b`), dispatch: def.Dispatch, separator: def.Separator},
+			compiledShorthand{pattern: regexp.MustCompile(`\b` + escaped + `-(\d{1,2})\b`), dispatch: def.Dispatch, separator: def.Separator},
+			compiledShorthand{pattern: regexp.MustCompile(`\b` + escaped + `(\d{1,2})\b`), dispatch: def.Dispatch, separator: def.Separator},
+		)
+	}
+
+	return p
+}
+
+// ParseTranscript extracts all units and channels from transcript.
+func (p *TranscriptParser) ParseTranscript(transcript string) ([]ParsedUnit, []ParsedChannel) {
+	return p.ParseUnits(transcript), p.ParseChannels(transcript)
+}
+
+// levenshtein computes the edit distance between two ASCII strings.
+func levenshtein(a, b string) int {
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	if a == b {
+		return 0
+	}
+
+	// Ensure a is the shorter string for O(min(m,n)) space.
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+
+	prev := make([]int, len(a)+1)
+	curr := make([]int, len(a)+1)
+
+	for i := range prev {
+		prev[i] = i
+	}
+
+	for j := 1; j <= len(b); j++ {
+		curr[0] = j
+		for i := 1; i <= len(a); i++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[i] + 1
+			ins := curr[i-1] + 1
+			sub := prev[i-1] + cost
+			curr[i] = min(del, min(ins, sub))
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[len(a)]
+}
+
+func tokenize(s string) []token {
+	indices := tokenPattern.FindAllStringIndex(s, -1)
+	tokens := make([]token, len(indices))
+	for i, idx := range indices {
+		tokens[i] = token{text: s[idx[0]:idx[1]], index: idx[0]}
+	}
+	return tokens
+}
+
+func isDigitToken(s string, maxLen int) bool {
+	if len(s) == 0 || len(s) > maxLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func stripSpaces(s string) string {
+	return strings.ReplaceAll(s, " ", "")
+}
+
+func findCandidates(tokens []token, wordList []FuzzyWord, skipIndices map[int]bool, maxMerge int) []Candidate {
+	var candidates []Candidate
+
+	for i := 0; i < len(tokens); i++ {
+		if skipIndices[i] {
+			continue
+		}
+		if isDigits(tokens[i].text) {
+			continue
+		}
+
+		for m := 0; m < maxMerge && i+m < len(tokens); m++ {
+			endIdx := i + m
+			if isDigits(tokens[endIdx].text) {
+				break
+			}
+			if m > 0 && skipIndices[endIdx] {
+				break
+			}
+
+			// Merge token texts. Spaces stripped so multi-word entries like
+			// "MEDIC ENGINE" match merged tokens "MEDICENGINE".
+			var merged string
+			if m == 0 {
+				merged = tokens[i].text
+			} else {
+				var sb strings.Builder
+				for k := i; k <= endIdx; k++ {
+					sb.WriteString(tokens[k].text)
+				}
+				merged = sb.String()
+			}
+
+			// Exact match
+			found := false
+			for _, w := range wordList {
+				if stripSpaces(w.Word) == merged {
+					candidates = append(candidates, Candidate{match: w.Word, distance: 0, startIdx: i, endIdx: endIdx})
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+
+			// Alias match
+			for _, w := range wordList {
+				for _, alias := range w.Aliases {
+					if stripSpaces(alias) == merged {
+						candidates = append(candidates, Candidate{match: w.Word, distance: 0, startIdx: i, endIdx: endIdx})
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+			if found {
+				break
+			}
+
+			// Fuzzy match
+			bestDist := -1
+			var bestMatch string
+			for _, w := range wordList {
+				if w.MaxDistance == 0 {
+					continue
+				}
+				dist := levenshtein(merged, stripSpaces(w.Word))
+				if dist > 0 && dist <= int(w.MaxDistance) {
+					if bestDist == -1 || dist < bestDist {
+						bestMatch = w.Word
+						bestDist = dist
+					}
+				}
+			}
+			if bestDist >= 0 {
+				candidates = append(candidates, Candidate{match: bestMatch, distance: uint8(bestDist), startIdx: i, endIdx: endIdx})
+				break
+			}
+		}
+	}
+
+	return candidates
+}
+
+func overlaps(a, b Candidate) bool {
+	return a.startIdx <= b.endIdx && b.startIdx <= a.endIdx
+}
+
+func rejectListFor(wordList []FuzzyWord, word string) []string {
+	for _, w := range wordList {
+		if w.Word == word {
+			return w.Reject
+		}
+	}
+	return nil
+}
+
+// precedesToken checks if any reject word appears as the token immediately
+// before startIdx in the token list.
+func precedesToken(tokens []token, startIdx int, rejectWords []string) bool {
+	if startIdx <= 0 || len(rejectWords) == 0 {
+		return false
+	}
+	prev := tokens[startIdx-1].text
+	for _, r := range rejectWords {
+		if prev == r {
+			return true
+		}
+	}
+	return false
+}
+
+// precedesByte checks if any reject word appears immediately before bytePos
+// in the normalized string.
+func precedesByte(normalized string, bytePos int, rejectWords []string) bool {
+	if bytePos <= 0 || len(rejectWords) == 0 {
+		return false
+	}
+	before := strings.TrimRight(normalized[:bytePos], " ,.")
+	for _, r := range rejectWords {
+		if strings.HasSuffix(before, r) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// matchSeparator checks tokenText against the configured separator list
+// (exact -> alias -> fuzzy) and returns the canonical separator word.
+func matchSeparator(tokenText string, separators []FuzzyWord) (string, bool) {
+	for _, s := range separators {
+		if tokenText == s.Word {
+			return s.Word, true
+		}
+		for _, alias := range s.Aliases {
+			if tokenText == alias {
+				return s.Word, true
+			}
+		}
+	}
+	for _, s := range separators {
+		if s.MaxDistance == 0 {
+			continue
+		}
+		if levenshtein(tokenText, s.Word) <= int(s.MaxDistance) {
+			return s.Word, true
+		}
+	}
+	return "", false
+}
+
+// channelKey builds the deduplication key for a ParsedChannel.
+func channelKey(dispatch, separator, channel string) string {
+	if separator == "" {
+		return dispatch + " " + channel
+	}
+	return dispatch + " " + separator + " " + channel
+}
+
+// CorrectTranscript replaces common mis-transcriptions with their correct
+// forms using the configured fuzzy corrections list.
+func (p *TranscriptParser) CorrectTranscript(transcript string) string {
+	if transcript == "" || len(p.cfg.Corrections) == 0 {
+		return transcript
+	}
+
+	normalized := strings.ToUpper(transcript)
+	tokens := tokenize(normalized)
+	if len(tokens) == 0 {
+		return transcript
+	}
+
+	candidates := findCandidates(tokens, p.cfg.Corrections, make(map[int]bool), 3)
+	if len(candidates) == 0 {
+		return transcript
+	}
+
+	// Sort by distance (best first), position as tiebreaker.
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].distance != candidates[j].distance {
+			return candidates[i].distance < candidates[j].distance
+		}
+		return candidates[i].startIdx < candidates[j].startIdx
+	})
+
+	// Greedily select non-overlapping candidates.
+	var selected []Candidate
+	for _, c := range candidates {
+		conflict := false
+		for _, s := range selected {
+			if overlaps(c, s) {
+				conflict = true
+				break
+			}
+		}
+		if !conflict {
+			selected = append(selected, c)
+		}
+	}
+
+	// Re-sort by position for right-to-left replacement.
+	sort.Slice(selected, func(i, j int) bool {
+		return selected[i].startIdx < selected[j].startIdx
+	})
+
+	result := normalized
+	for i := len(selected) - 1; i >= 0; i-- {
+		c := selected[i]
+		byteStart := tokens[c.startIdx].index
+		endTok := tokens[c.endIdx]
+		byteEnd := endTok.index + len(endTok.text)
+		result = result[:byteStart] + c.match + result[byteEnd:]
+	}
+
+	return result
+}
+
+// ParseUnits extracts apparatus units (e.g. "ENGINE 5", "MEDIC LADDER 12") from
+// transcript using the configured unit types and prefixes.
+func (p *TranscriptParser) ParseUnits(transcript string) []ParsedUnit {
+	if transcript == "" || p.unitPattern == nil {
+		return []ParsedUnit{}
+	}
+
+	normalized := strings.ToUpper(transcript)
+	seen := make(map[string]int) // key -> index in results
+	var results []ParsedUnit
+
+	// Track character ranges consumed by exact matches.
+	var consumed [][2]int
+
+	// --- Pass 1: exact regex ---
+	matches := p.unitPattern.FindAllStringSubmatchIndex(normalized, -1)
+	for _, m := range matches {
+		fullMatch := normalized[m[0]:m[1]]
+
+		var prefix, apparatus, number string
+		var checkPos int
+
+		if p.unitHasPrefix {
+			// Groups: (prefix)? (apparatus) (number)
+			if m[2] >= 0 {
+				prefix = normalized[m[2]:m[3]]
+			}
+			apparatus = normalized[m[4]:m[5]]
+			number = normalized[m[6]:m[7]]
+			checkPos = m[4]
+			if prefix != "" {
+				checkPos = m[2]
+			}
+		} else {
+			// Groups: (apparatus) (number)
+			apparatus = normalized[m[2]:m[3]]
+			number = normalized[m[4]:m[5]]
+			checkPos = m[2]
+		}
+
+		if rejectWords := rejectListFor(p.cfg.UnitTypes, apparatus); precedesByte(normalized, checkPos, rejectWords) {
+			continue
+		}
+
+		key := strings.TrimSpace(prefix + " " + apparatus + " " + number)
+
+		if idx, ok := seen[key]; ok {
+			if !containsString(results[idx].Raw, fullMatch) {
+				results[idx].Raw = append(results[idx].Raw, fullMatch)
+			}
+		} else {
+			seen[key] = len(results)
+			results = append(results, ParsedUnit{
+				Prefix:    prefix,
+				Apparatus: apparatus,
+				Number:    number,
+				Raw:       []string{fullMatch},
+				Fuzzy:     false,
+			})
+		}
+		consumed = append(consumed, [2]int{m[0], m[1]})
+	}
+
+	// --- Pass 2: fuzzy label + assemble ---
+	tokens := tokenize(normalized)
+
+	exactConsumed := make(map[int]bool)
+	for i, tk := range tokens {
+		for _, c := range consumed {
+			if tk.index >= c[0] && tk.index < c[1] {
+				exactConsumed[i] = true
+				break
+			}
+		}
+	}
+
+	prefixCandidates := findCandidates(tokens, p.cfg.UnitPrefixes, exactConsumed, 3)
+	unitCandidates := findCandidates(tokens, p.cfg.UnitTypes, exactConsumed, 3)
+
+	assemblyConsumed := make(map[int]bool)
+
+	for _, unit := range unitCandidates {
+		skip := false
+		for idx := unit.startIdx; idx <= unit.endIdx; idx++ {
+			if assemblyConsumed[idx] {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+
+		if rejectWords := rejectListFor(p.cfg.UnitTypes, unit.match); precedesToken(tokens, unit.startIdx, rejectWords) {
+			continue
+		}
+
+		// The token immediately after the unit must be a 1-3 digit number.
+		numIdx := unit.endIdx + 1
+		if numIdx >= len(tokens) {
+			continue
+		}
+		numToken := tokens[numIdx]
+		if !isDigitToken(numToken.text, 3) {
+			continue
+		}
+		if assemblyConsumed[numIdx] {
+			continue
+		}
+
+		number := numToken.text
+
+		// Look for the best prefix candidate ending right before this unit.
+		var bestPrefix *Candidate
+		for ci := range prefixCandidates {
+			pc := &prefixCandidates[ci]
+			if pc.endIdx != unit.startIdx-1 {
+				continue
+			}
+			if overlaps(*pc, unit) {
+				continue
+			}
+
+			prefixUsed := false
+			for idx := pc.startIdx; idx <= pc.endIdx; idx++ {
+				if assemblyConsumed[idx] {
+					prefixUsed = true
+					break
+				}
+			}
+			if prefixUsed {
+				continue
+			}
+
+			if bestPrefix == nil || pc.distance < bestPrefix.distance {
+				bestPrefix = pc
+			}
+		}
+
+		var prefix string
+		if bestPrefix != nil {
+			prefix = bestPrefix.match
+		}
+		apparatus := unit.match
+		key := strings.TrimSpace(prefix + " " + apparatus + " " + number)
+
+		rawStart := tokens[unit.startIdx].index
+		if bestPrefix != nil {
+			rawStart = tokens[bestPrefix.startIdx].index
+		}
+		rawEnd := numToken.index + len(numToken.text)
+		raw := normalized[rawStart:rawEnd]
+
+		if idx, ok := seen[key]; ok {
+			if !containsString(results[idx].Raw, raw) {
+				results[idx].Raw = append(results[idx].Raw, raw)
+			}
+		} else {
+			seen[key] = len(results)
+			results = append(results, ParsedUnit{
+				Prefix:    prefix,
+				Apparatus: apparatus,
+				Number:    number,
+				Raw:       []string{raw},
+				Fuzzy:     true,
+			})
+		}
+
+		if bestPrefix != nil {
+			for idx := bestPrefix.startIdx; idx <= bestPrefix.endIdx; idx++ {
+				assemblyConsumed[idx] = true
+			}
+		}
+		for idx := unit.startIdx; idx <= unit.endIdx; idx++ {
+			assemblyConsumed[idx] = true
+		}
+		assemblyConsumed[numIdx] = true
+	}
+
+	// --- Pass 3: prefix upgrade for exact matches with no prefix ---
+	for ri := range results {
+		result := &results[ri]
+		if result.Prefix != "" || result.Fuzzy {
+			continue
+		}
+
+		matchCharStart := strings.Index(normalized, result.Raw[0])
+		if matchCharStart == -1 {
+			continue
+		}
+
+		unitTokenIdx := -1
+		for i, tk := range tokens {
+			if tk.index == matchCharStart {
+				unitTokenIdx = i
+				break
+			}
+		}
+		if unitTokenIdx <= 0 {
+			continue
+		}
+
+		var bestPrefix *Candidate
+		for ci := range prefixCandidates {
+			pc := &prefixCandidates[ci]
+			if pc.endIdx != unitTokenIdx-1 {
+				continue
+			}
+
+			prefixUsed := false
+			for idx := pc.startIdx; idx <= pc.endIdx; idx++ {
+				if assemblyConsumed[idx] {
+					prefixUsed = true
+					break
+				}
+			}
+			if prefixUsed {
+				continue
+			}
+
+			if bestPrefix == nil || pc.distance < bestPrefix.distance {
+				bestPrefix = pc
+			}
+		}
+
+		if bestPrefix == nil {
+			continue
+		}
+
+		oldKey := strings.TrimSpace(result.Apparatus + " " + result.Number)
+		newKey := bestPrefix.match + " " + result.Apparatus + " " + result.Number
+		if _, exists := seen[newKey]; exists {
+			continue
+		}
+		delete(seen, oldKey)
+		seen[newKey] = ri
+
+		result.Prefix = bestPrefix.match
+		rawStart := tokens[bestPrefix.startIdx].index
+		newRaw := make([]string, len(result.Raw))
+		for i, r := range result.Raw {
+			rStart := strings.Index(normalized, r)
+			if rStart == -1 {
+				newRaw[i] = r
+			} else {
+				newRaw[i] = normalized[rawStart : rStart+len(r)]
+			}
+		}
+		result.Raw = newRaw
+
+		for idx := bestPrefix.startIdx; idx <= bestPrefix.endIdx; idx++ {
+			assemblyConsumed[idx] = true
+		}
+	}
+
+	return results
+}
+
+// ParseChannels extracts dispatch channels from transcript using the configured
+// dispatch names, channel separators, and shorthands.
+//
+// The channel format depends on how ChannelSeparators is configured:
+//   - With separators: "{Dispatch} {Separator} {Number}"  (e.g. "CITY FIRE 3", "METRO POLICE 2")
+//   - Without separators: "{Dispatch} {Number}"           (e.g. "CITY 3")
+//
+// Shorthands are always matched regardless of the separator config.
+func (p *TranscriptParser) ParseChannels(transcript string) []ParsedChannel {
+	if transcript == "" || (p.channelPattern == nil && len(p.channelShorthands) == 0) {
+		return []ParsedChannel{}
+	}
+
+	normalized := strings.ToUpper(transcript)
+	seen := make(map[string]int)
+	var results []ParsedChannel
+	var consumed [][2]int
+
+	addOrMerge := func(dispatch, separator, channel, raw string, fuzzy bool) {
+		key := channelKey(dispatch, separator, channel)
+		if idx, ok := seen[key]; ok {
+			if !containsString(results[idx].Raw, raw) {
+				results[idx].Raw = append(results[idx].Raw, raw)
+			}
+		} else {
+			seen[key] = len(results)
+			results = append(results, ParsedChannel{
+				Dispatch:  dispatch,
+				Separator: separator,
+				Channel:   channel,
+				Raw:       []string{raw},
+				Fuzzy:     fuzzy,
+			})
+		}
+	}
+
+	// --- Pass 1: exact regex ---
+	if p.channelPattern != nil {
+		matches := p.channelPattern.FindAllStringSubmatchIndex(normalized, -1)
+		for _, m := range matches {
+			fullMatch := normalized[m[0]:m[1]]
+			var dispatch, separator, channel string
+			if p.channelHasSep {
+				// Groups: (dispatch) (separator) (number)
+				dispatch = normalized[m[2]:m[3]]
+				separator = normalized[m[4]:m[5]]
+				channel = normalized[m[6]:m[7]]
+			} else {
+				// Groups: (dispatch) (number)
+				dispatch = normalized[m[2]:m[3]]
+				channel = normalized[m[4]:m[5]]
+			}
+			addOrMerge(dispatch, separator, channel, fullMatch, false)
+			consumed = append(consumed, [2]int{m[0], m[1]})
+		}
+	}
+
+	// --- Pass 1b: shorthand patterns ---
+	for _, sh := range p.channelShorthands {
+		shMatches := sh.pattern.FindAllStringSubmatchIndex(normalized, -1)
+		for _, m := range shMatches {
+			fullMatch := normalized[m[0]:m[1]]
+			channel := normalized[m[2]:m[3]]
+			addOrMerge(sh.dispatch, sh.separator, channel, fullMatch, false)
+			consumed = append(consumed, [2]int{m[0], m[1]})
+		}
+	}
+
+	// --- Pass 2: fuzzy dispatch (+ optional separator) + number ---
+	tokens := tokenize(normalized)
+
+	exactConsumed := make(map[int]bool)
+	for i, tk := range tokens {
+		for _, c := range consumed {
+			if tk.index >= c[0] && tk.index < c[1] {
+				exactConsumed[i] = true
+				break
+			}
+		}
+	}
+
+	dispatchCandidates := findCandidates(tokens, p.cfg.DispatchNames, exactConsumed, 2)
+
+	for _, dc := range dispatchCandidates {
+		nextIdx := dc.endIdx + 1
+		if nextIdx >= len(tokens) {
+			continue
+		}
+
+		var separator, channel string
+		var numToken token
+
+		if len(p.cfg.ChannelSeparators) > 0 {
+			// Expect a separator token then a number.
+			sep, ok := matchSeparator(tokens[nextIdx].text, p.cfg.ChannelSeparators)
+			if !ok {
+				continue
+			}
+			separator = sep
+
+			numIdx := nextIdx + 1
+			if numIdx >= len(tokens) {
+				continue
+			}
+			numToken = tokens[numIdx]
+			if !isDigitToken(numToken.text, 2) {
+				continue
+			}
+			channel = numToken.text
+		} else {
+			// No separator — next token must be the number directly.
+			if !isDigitToken(tokens[nextIdx].text, 2) {
+				continue
+			}
+			numToken = tokens[nextIdx]
+			channel = numToken.text
+		}
+
+		rawStart := tokens[dc.startIdx].index
+		rawEnd := numToken.index + len(numToken.text)
+		raw := normalized[rawStart:rawEnd]
+
+		addOrMerge(dc.match, separator, channel, raw, true)
+	}
+
+	return results
+}

--- a/server/transcript_parser.go
+++ b/server/transcript_parser.go
@@ -848,6 +848,61 @@ func (p *TranscriptParser) AnnotateTranscript(transcript string) (string, []Tran
 		return annotations[i].Start < annotations[j].Start
 	})
 
+	// Substitute canonical forms into the corrected transcript string so that
+	// the returned text reflects what was recognized (e.g. alias "DECK, FIRE 3"
+	// becomes "VECC FIRE 3", fuzzy "ENGNE 5" becomes "ENGINE 5").
+	// Process left-to-right with a cumulative delta so that each annotation's
+	// Start/End is adjusted for all prior substitutions before use.
+	delta := 0
+	for i := range annotations {
+		ann := &annotations[i]
+		ann.Start += delta
+		ann.End += delta
+
+		var canonical string
+		if ann.Type == "unit" {
+			parts := make([]string, 0, 3)
+			if ann.Prefix != "" {
+				parts = append(parts, ann.Prefix)
+			}
+			parts = append(parts, ann.Apparatus, ann.Number)
+			canonical = strings.Join(parts, " ")
+		} else {
+			parts := make([]string, 0, 3)
+			parts = append(parts, ann.Dispatch)
+			if ann.Separator != "" {
+				parts = append(parts, ann.Separator)
+			}
+			parts = append(parts, ann.Channel)
+			canonical = strings.Join(parts, " ")
+		}
+		if canonical == ann.Text {
+			continue
+		}
+		origLen := ann.End - ann.Start
+		corrected = corrected[:ann.Start] + canonical + corrected[ann.End:]
+		ann.End = ann.Start + len(canonical)
+		ann.Text = canonical
+		delta += len(canonical) - origLen
+	}
+
+	// Convert byte offsets to Unicode code-point (rune) offsets.
+	// Go strings are UTF-8 (byte-indexed); JavaScript strings are UTF-16
+	// (character-indexed). They differ when the transcript contains multi-byte
+	// characters such as an em-dash "—" (3 bytes in UTF-8, 1 char in JS).
+	// Build a byte→rune index map so annotation positions are valid in JS.
+	byteToRune := make([]int, len(corrected)+1)
+	ri := 0
+	for bi := range corrected {
+		byteToRune[bi] = ri
+		ri++
+	}
+	byteToRune[len(corrected)] = ri
+	for i := range annotations {
+		annotations[i].Start = byteToRune[annotations[i].Start]
+		annotations[i].End = byteToRune[annotations[i].End]
+	}
+
 	return corrected, annotations
 }
 

--- a/server/transcript_parser.go
+++ b/server/transcript_parser.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 )
 
 //! Important Note: This parser is optimized for Fire Department dispatches
@@ -76,6 +77,27 @@ type ParsedChannel struct {
 	Raw       []string `json:"raw"`
 	Fuzzy     bool     `json:"fuzzy"`
 }
+
+// TranscriptAnnotation describes a recognized unit or channel at a specific
+// byte range within the corrected transcript string returned by AnnotateTranscript.
+type TranscriptAnnotation struct {
+	Type      string `json:"type"`                // "unit" or "channel"
+	Text      string `json:"text"`                // raw text as found in transcript
+	Start     int    `json:"start"`               // byte offset in corrected transcript (inclusive)
+	End       int    `json:"end"`                 // byte offset in corrected transcript (exclusive)
+	Prefix    string `json:"prefix,omitempty"`    // unit prefix, e.g. "MEDIC"
+	Apparatus string `json:"apparatus,omitempty"` // unit type, e.g. "ENGINE"
+	Number    string `json:"number,omitempty"`    // unit or channel number
+	Dispatch  string `json:"dispatch,omitempty"`  // channel dispatch name
+	Separator string `json:"separator,omitempty"` // channel separator word
+	Channel   string `json:"channel,omitempty"`   // channel number
+	Fuzzy     bool   `json:"fuzzy"`               // true if fuzzy-matched
+}
+
+// activeTranscriptParser is the live parser instance, updated whenever the
+// admin saves a new TranscriptParserConfig. Package-level so MarshalJSON
+// methods can access it without holding a controller reference.
+var activeTranscriptParser atomic.Pointer[TranscriptParser]
 
 // Candidate represents a possible fuzzy or exact match at a token position.
 type Candidate struct {
@@ -746,6 +768,87 @@ func (p *TranscriptParser) ParseUnits(transcript string) []ParsedUnit {
 	}
 
 	return results
+}
+
+// AnnotateTranscript applies corrections to transcript, parses units and channels,
+// and returns the corrected string along with position-annotated results.
+// The corrected string is always uppercase (normalized by CorrectTranscript).
+// Start/End offsets reference byte positions in the returned corrected string.
+// Returns ("", nil) for empty input. Safe to call on a nil parser.
+func (p *TranscriptParser) AnnotateTranscript(transcript string) (string, []TranscriptAnnotation) {
+	if p == nil || transcript == "" {
+		return transcript, nil
+	}
+
+	corrected := p.CorrectTranscript(transcript)
+	units := p.ParseUnits(corrected)
+	channels := p.ParseChannels(corrected)
+
+	if len(units) == 0 && len(channels) == 0 {
+		return corrected, nil
+	}
+
+	var annotations []TranscriptAnnotation
+
+	for _, unit := range units {
+		for _, raw := range unit.Raw {
+			offset := 0
+			for {
+				idx := strings.Index(corrected[offset:], raw)
+				if idx == -1 {
+					break
+				}
+				start := offset + idx
+				end := start + len(raw)
+				annotations = append(annotations, TranscriptAnnotation{
+					Type:      "unit",
+					Text:      raw,
+					Start:     start,
+					End:       end,
+					Prefix:    unit.Prefix,
+					Apparatus: unit.Apparatus,
+					Number:    unit.Number,
+					Fuzzy:     unit.Fuzzy,
+				})
+				offset = end
+			}
+		}
+	}
+
+	for _, ch := range channels {
+		for _, raw := range ch.Raw {
+			offset := 0
+			for {
+				idx := strings.Index(corrected[offset:], raw)
+				if idx == -1 {
+					break
+				}
+				start := offset + idx
+				end := start + len(raw)
+				annotations = append(annotations, TranscriptAnnotation{
+					Type:      "channel",
+					Text:      raw,
+					Start:     start,
+					End:       end,
+					Dispatch:  ch.Dispatch,
+					Separator: ch.Separator,
+					Channel:   ch.Channel,
+					Fuzzy:     ch.Fuzzy,
+				})
+				offset = end
+			}
+		}
+	}
+
+	if len(annotations) == 0 {
+		return corrected, nil
+	}
+
+	sort.Slice(annotations, func(i, j int) bool {
+		return annotations[i].Start < annotations[j].Start
+	})
+
+	return corrected, annotations
 }
 
 // ParseChannels extracts dispatch channels from transcript using the configured

--- a/server/transcript_parser_test.go
+++ b/server/transcript_parser_test.go
@@ -1,0 +1,948 @@
+// Copyright (C) 2026 Carter Carling <carter@cartercarling.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package main
+
+import (
+	"testing"
+)
+
+// testConfig is the word list used across all tests
+// The word lists were created from errors found in real dispatch transcripts
+var testConfig = TranscriptConfig{
+	UnitTypes: []FuzzyWord{
+		{Word: "ENGINE", MaxDistance: 2},
+		{Word: "TRUCK", MaxDistance: 1, Aliases: []string{"TREK", "TRUK", "CHUG", "TUG", "CHOP"}},
+		{Word: "TOWER", MaxDistance: 1},
+		{Word: "LADDER", MaxDistance: 2},
+		{Word: "CHAT", MaxDistance: 0, Aliases: []string{"CAT", "CHAD", "CHATT"}},
+		{Word: "SQUAD", MaxDistance: 1},
+		{Word: "QUINT", MaxDistance: 1, Aliases: []string{"QUINN"}},
+		{Word: "HAZMAT", MaxDistance: 2},
+		{Word: "BATTALION", MaxDistance: 2},
+		{Word: "RED", MaxDistance: 0, Aliases: []string{"WRED", "REDD", "RAD"}},
+		{Word: "AMBULANCE", MaxDistance: 2},
+		{Word: "RESCUE", MaxDistance: 2, Aliases: []string{"RESQ", "RESQUE", "RESQEU"}, Reject: []string{"ELEVATOR"}},
+		{Word: "UTILITY", MaxDistance: 2},
+		{Word: "TENDER", MaxDistance: 2},
+		{Word: "REHAB", MaxDistance: 1},
+		{Word: "COMPANY", MaxDistance: 2},
+		{Word: "LU", MaxDistance: 0, Aliases: []string{"LOU", "LUA", "LUR"}},
+		{Word: "MEDIC", MaxDistance: 0},
+	},
+	UnitPrefixes: []FuzzyWord{
+		{Word: "MEDIC", MaxDistance: 1},
+		{Word: "HEAVY", MaxDistance: 1},
+		{Word: "HEAVY MEDIC", MaxDistance: 2},
+		{Word: "BRUSH", MaxDistance: 1},
+		{Word: "TACTICAL", MaxDistance: 2},
+	},
+	DispatchNames: []FuzzyWord{
+		{Word: "CITY", MaxDistance: 1},
+		{Word: "VECC", MaxDistance: 1, Aliases: []string{"VEC", "DECK", "TECH", "VAC", "VEX", "VIC"}},
+		{Word: "SANDY", MaxDistance: 1},
+	},
+	ChannelSeparators: []FuzzyWord{
+		{Word: "FIRE", MaxDistance: 1},
+	},
+	ChannelShorthands: []ChannelShorthand{
+		{Label: "SF", Dispatch: "SANDY", Separator: "FIRE"},
+		{Label: "BACKFIRE", Dispatch: "VECC", Separator: "FIRE"},
+		{Label: "CITY AIR", Dispatch: "CITY", Separator: "FIRE"},
+		{Label: "X-FIRE", Dispatch: "VECC", Separator: "FIRE"},
+	},
+	Corrections: []FuzzyWord{
+		{Word: "SHORT FALL", MaxDistance: 2, Aliases: []string{"SHEFFIELD", "CHILWORTH FALL", "CHILLICOTHE FALL", "SHORTFALL", "SHILLER'S FALL"}},
+		{Word: "UNKNOWN MEDICAL", MaxDistance: 1, Aliases: []string{"A KNOWN MEDICAL"}},
+		{Word: "STROKE OR CVA", MaxDistance: 1},
+	},
+}
+
+var testParser = NewTranscriptParser(testConfig)
+
+// --- Levenshtein ---
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"ENGINE", "ENGINE", 0},
+		{"", "ABC", 3},
+		{"ABC", "", 3},
+		{"ENGIN", "ENGINE", 1},
+		{"ENGNE", "ENGINE", 1},
+		{"TRUCK", "TREK", 2},
+		{"RESQ", "RESCUE", 3},
+		{"KITTEN", "SITTING", 3},
+	}
+	for _, tt := range tests {
+		got := levenshtein(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestLevenshteinSymmetric(t *testing.T) {
+	pairs := [][2]string{
+		{"ABC", "DEF"},
+		{"ENGINE", "ENGIN"},
+		{"TRUCK", "TREK"},
+	}
+	for _, p := range pairs {
+		ab := levenshtein(p[0], p[1])
+		ba := levenshtein(p[1], p[0])
+		if ab != ba {
+			t.Errorf("levenshtein(%q,%q)=%d but levenshtein(%q,%q)=%d", p[0], p[1], ab, p[1], p[0], ba)
+		}
+	}
+}
+
+// --- Helper functions ---
+
+func TestTokenize(t *testing.T) {
+	tokens := tokenize("ENGINE 5 RESPONDING ON SCENE")
+	texts := make([]string, len(tokens))
+	for i, tk := range tokens {
+		texts[i] = tk.text
+	}
+	want := []string{"ENGINE", "5", "RESPONDING", "ON", "SCENE"}
+	if len(texts) != len(want) {
+		t.Fatalf("tokenize got %v, want %v", texts, want)
+	}
+	for i := range want {
+		if texts[i] != want[i] {
+			t.Errorf("token[%d] = %q, want %q", i, texts[i], want[i])
+		}
+	}
+}
+
+func TestTokenizePreservesIndex(t *testing.T) {
+	input := "AB 12 CD"
+	tokens := tokenize(input)
+	for _, tk := range tokens {
+		got := input[tk.index : tk.index+len(tk.text)]
+		if got != tk.text {
+			t.Errorf("token %q at index %d does not match source %q", tk.text, tk.index, got)
+		}
+	}
+}
+
+func TestIsDigitToken(t *testing.T) {
+	tests := []struct {
+		s      string
+		maxLen int
+		want   bool
+	}{
+		{"123", 3, true},
+		{"1234", 3, false},
+		{"0", 3, true},
+		{"", 3, false},
+		{"12A", 3, false},
+		{"99", 2, true},
+	}
+	for _, tt := range tests {
+		got := isDigitToken(tt.s, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("isDigitToken(%q, %d) = %v, want %v", tt.s, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+// --- Unit parsing ---
+
+func TestParseUnitsExact(t *testing.T) {
+	results := testParser.ParseUnits("ENGINE 5 TRUCK 12")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Apparatus != "ENGINE" || results[0].Number != "5" || results[0].Fuzzy {
+		t.Errorf("result[0] = %+v, want ENGINE 5 non-fuzzy", results[0])
+	}
+	if results[1].Apparatus != "TRUCK" || results[1].Number != "12" || results[1].Fuzzy {
+		t.Errorf("result[1] = %+v, want TRUCK 12 non-fuzzy", results[1])
+	}
+}
+
+func TestParseUnitsWithPrefix(t *testing.T) {
+	results := testParser.ParseUnits("MEDIC ENGINE 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Prefix != "MEDIC" || r.Apparatus != "ENGINE" || r.Number != "5" {
+		t.Errorf("got %+v, want MEDIC ENGINE 5", r)
+	}
+}
+
+func TestParseUnitsFuzzy(t *testing.T) {
+	results := testParser.ParseUnits("ENGNE 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Apparatus != "ENGINE" || r.Number != "5" || !r.Fuzzy {
+		t.Errorf("got %+v, want fuzzy ENGINE 5", r)
+	}
+}
+
+func TestParseUnitsAlias(t *testing.T) {
+	results := testParser.ParseUnits("TREK 3")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Apparatus != "TRUCK" || r.Number != "3" || !r.Fuzzy {
+		t.Errorf("got %+v, want fuzzy TRUCK 3", r)
+	}
+}
+
+func TestParseUnitsDedup(t *testing.T) {
+	results := testParser.ParseUnits("ENGINE 5 AND ENGINE 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (deduped), got %d", len(results))
+	}
+	if results[0].Apparatus != "ENGINE" || results[0].Number != "5" {
+		t.Errorf("got %+v, want ENGINE 5", results[0])
+	}
+}
+
+func TestParseUnitsReject(t *testing.T) {
+	// "ELEVATOR RESCUE 160" should NOT parse RESCUE 160 as a unit
+	results := testParser.ParseUnits("TRUCK 2, ELEVATOR RESCUE 160 SOUTH 300 WEST")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (TRUCK 2 only), got %d: %+v", len(results), results)
+	}
+	if results[0].Apparatus != "TRUCK" || results[0].Number != "2" {
+		t.Errorf("got %+v, want TRUCK 2", results[0])
+	}
+}
+
+func TestParseUnitsRejectDoesNotAffectNormal(t *testing.T) {
+	// "RESCUE 3" without a reject word before it should still match
+	results := testParser.ParseUnits("RESCUE 3 RESPONDING")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Apparatus != "RESCUE" || results[0].Number != "3" {
+		t.Errorf("got %+v, want RESCUE 3", results[0])
+	}
+}
+
+func TestParseUnitsMedicAsUnit(t *testing.T) {
+	results := testParser.ParseUnits("MEDIC 6 RESPONDING")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %+v", len(results), results)
+	}
+	if results[0].Apparatus != "MEDIC" || results[0].Number != "6" {
+		t.Errorf("got %+v, want MEDIC 6", results[0])
+	}
+}
+
+func TestParseUnitsMedicAsPrefix(t *testing.T) {
+	results := testParser.ParseUnits("MEDIC ENGINE 5 RESPONDING")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %+v", len(results), results)
+	}
+	if results[0].Prefix != "MEDIC" || results[0].Apparatus != "ENGINE" || results[0].Number != "5" {
+		t.Errorf("got %+v, want MEDIC ENGINE 5", results[0])
+	}
+}
+
+func TestParseUnitsMedicBoth(t *testing.T) {
+	results := testParser.ParseUnits("MEDIC 6 AND MEDIC ENGINE 5")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d: %+v", len(results), results)
+	}
+}
+
+func TestParseUnitsEmpty(t *testing.T) {
+	results := testParser.ParseUnits("")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestParseUnitsAllTypes(t *testing.T) {
+	// Every unit type (except MEDIC, which has its own prefix/unit duality tests)
+	// should be recognised in an exact match
+	types := []string{
+		"ENGINE", "TRUCK", "TOWER", "LADDER", "CHAT", "SQUAD",
+		"QUINT", "HAZMAT", "BATTALION", "RED", "AMBULANCE",
+		"RESCUE", "UTILITY", "TENDER", "REHAB", "COMPANY", "LU",
+	}
+	for _, typ := range types {
+		results := testParser.ParseUnits(typ + " 1")
+		if len(results) != 1 {
+			t.Errorf("%s 1: expected 1 result, got %d", typ, len(results))
+			continue
+		}
+		if results[0].Apparatus != typ {
+			t.Errorf("%s 1: apparatus = %q, want %q", typ, results[0].Apparatus, typ)
+		}
+		if results[0].Fuzzy {
+			t.Errorf("%s 1: should not be fuzzy", typ)
+		}
+	}
+}
+
+func TestParseUnitsAllAliases(t *testing.T) {
+	tests := []struct {
+		alias string
+		want  string
+	}{
+		{"TREK", "TRUCK"},
+		{"TRUK", "TRUCK"},
+		{"CHUG", "TRUCK"},
+		{"TUG", "TRUCK"},
+		{"CHOP", "TRUCK"},
+		{"CAT", "CHAT"},
+		{"CHAD", "CHAT"},
+		{"CHATT", "CHAT"},
+		{"QUINN", "QUINT"},
+		{"WRED", "RED"},
+		{"REDD", "RED"},
+		{"RAD", "RED"},
+		{"RESQ", "RESCUE"},
+		{"RESQUE", "RESCUE"},
+		{"RESQEU", "RESCUE"},
+		{"LOU", "LU"},
+		{"LUA", "LU"},
+		{"LUR", "LU"},
+	}
+	for _, tt := range tests {
+		results := testParser.ParseUnits(tt.alias + " 7")
+		if len(results) != 1 {
+			t.Errorf("%s 7: expected 1 result, got %d", tt.alias, len(results))
+			continue
+		}
+		if results[0].Apparatus != tt.want {
+			t.Errorf("%s 7: apparatus = %q, want %q", tt.alias, results[0].Apparatus, tt.want)
+		}
+		if !results[0].Fuzzy {
+			t.Errorf("%s 7: should be fuzzy", tt.alias)
+		}
+	}
+}
+
+func TestParseUnitsFuzzyDistance(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// ENGINE maxDistance=2: "ENGIN" is distance 1, "ENGNE" is distance 1
+		{"ENGIN 3", "ENGINE"},
+		{"ENGNE 3", "ENGINE"},
+		// LADDER maxDistance=2: "LADDR" is distance 2
+		{"LADDR 3", "LADDER"},
+		// SQUAD maxDistance=1: "SQAD" is distance 1
+		{"SQAD 3", "SQUAD"},
+	}
+	for _, tt := range tests {
+		results := testParser.ParseUnits(tt.input)
+		if len(results) != 1 {
+			t.Errorf("%q: expected 1 result, got %d", tt.input, len(results))
+			continue
+		}
+		if results[0].Apparatus != tt.want {
+			t.Errorf("%q: apparatus = %q, want %q", tt.input, results[0].Apparatus, tt.want)
+		}
+		if !results[0].Fuzzy {
+			t.Errorf("%q: should be fuzzy", tt.input)
+		}
+	}
+}
+
+func TestParseUnitsFuzzyTooFar(t *testing.T) {
+	// TRUCK maxDistance=1; "TRAK" is distance 2 — should not match
+	results := testParser.ParseUnits("TRAK 5")
+	for _, r := range results {
+		if r.Apparatus == "TRUCK" {
+			t.Errorf("TRAK should not fuzzy-match TRUCK (distance > maxDistance)")
+		}
+	}
+}
+
+func TestParseUnitsAllPrefixes(t *testing.T) {
+	prefixes := []string{"MEDIC", "HEAVY", "BRUSH", "TACTICAL"}
+	for _, p := range prefixes {
+		results := testParser.ParseUnits(p + " ENGINE 1")
+		if len(results) != 1 {
+			t.Errorf("%s ENGINE 1: expected 1 result, got %d", p, len(results))
+			continue
+		}
+		if results[0].Prefix != p {
+			t.Errorf("%s ENGINE 1: prefix = %q, want %q", p, results[0].Prefix, p)
+		}
+	}
+}
+
+func TestParseUnitsMultiWordPrefix(t *testing.T) {
+	results := testParser.ParseUnits("HEAVY MEDIC ENGINE 1")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Prefix != "HEAVY MEDIC" {
+		t.Errorf("prefix = %q, want HEAVY MEDIC", results[0].Prefix)
+	}
+}
+
+func TestParseUnitsThreeDigitNumber(t *testing.T) {
+	results := testParser.ParseUnits("ENGINE 123")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Number != "123" {
+		t.Errorf("number = %q, want 123", results[0].Number)
+	}
+}
+
+func TestParseUnitsFourDigitNumberIgnored(t *testing.T) {
+	results := testParser.ParseUnits("ENGINE 1234")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for 4-digit number, got %d: %+v", len(results), results)
+	}
+}
+
+func TestParseUnitsMultipleDistinct(t *testing.T) {
+	results := testParser.ParseUnits("ENGINE 5 LADDER 12 RESCUE 3")
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	want := []struct{ app, num string }{
+		{"ENGINE", "5"},
+		{"LADDER", "12"},
+		{"RESCUE", "3"},
+	}
+	for i, w := range want {
+		if results[i].Apparatus != w.app || results[i].Number != w.num {
+			t.Errorf("result[%d] = %s %s, want %s %s", i, results[i].Apparatus, results[i].Number, w.app, w.num)
+		}
+	}
+}
+
+func TestParseUnitsCaseInsensitive(t *testing.T) {
+	results := testParser.ParseUnits("engine 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for lowercase, got %d", len(results))
+	}
+	if results[0].Apparatus != "ENGINE" {
+		t.Errorf("apparatus = %q, want ENGINE", results[0].Apparatus)
+	}
+}
+
+func TestParseUnitsNoNumber(t *testing.T) {
+	results := testParser.ParseUnits("ENGINE RESPONDING")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for apparatus without number, got %d: %+v", len(results), results)
+	}
+}
+
+func TestParseUnitsDedupCollectsRaw(t *testing.T) {
+	// Exact match and alias for the same unit should dedup but collect both raw strings
+	results := testParser.ParseUnits("TRUCK 5 IS ON SCENE TREK 5 CLEAR")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduped result, got %d", len(results))
+	}
+	if len(results[0].Raw) < 2 {
+		t.Errorf("expected at least 2 raw strings, got %d: %v", len(results[0].Raw), results[0].Raw)
+	}
+}
+
+func TestParseUnitsFuzzyPrefix(t *testing.T) {
+	// MEDIC maxDistance=1: "MDIC" is distance 1
+	results := testParser.ParseUnits("MDIC ENGINE 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Prefix != "MEDIC" {
+		t.Errorf("prefix = %q, want MEDIC", results[0].Prefix)
+	}
+}
+
+func TestParseUnitsPrefixUpgrade(t *testing.T) {
+	// Pass 3: exact match without prefix should get upgraded when a prefix precedes it
+	results := testParser.ParseUnits("BRUSH ENGINE 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Prefix != "BRUSH" || results[0].Apparatus != "ENGINE" || results[0].Number != "5" {
+		t.Errorf("got %+v, want BRUSH ENGINE 5", results[0])
+	}
+}
+
+func TestParseUnits_NumberBeforeApparatus(t *testing.T) {
+	// "5 ENGINE" has the number before the apparatus — should not panic
+	results := testParser.ParseUnits("5 ENGINE")
+	for _, r := range results {
+		if r.Apparatus != "ENGINE" {
+			t.Errorf("expected apparatus ENGINE, got %q", r.Apparatus)
+		}
+	}
+}
+
+func TestParseUnits_MultiplePrefix(t *testing.T) {
+	results := testParser.ParseUnits("AIR MEDIC ENGINE 5")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Apparatus != "ENGINE" || r.Number != "5" {
+		t.Errorf("got %+v, want ENGINE 5", r)
+	}
+}
+
+// --- Channel parsing ---
+
+func TestParseChannelsExact(t *testing.T) {
+	results := testParser.ParseChannels("CITY FIRE 3")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Dispatch != "CITY" || r.Separator != "FIRE" || r.Channel != "3" || r.Fuzzy {
+		t.Errorf("got %+v, want CITY FIRE 3 non-fuzzy", r)
+	}
+}
+
+func TestParseChannelsShorthand(t *testing.T) {
+	results := testParser.ParseChannels("SF 3")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Dispatch != "SANDY" || r.Separator != "FIRE" || r.Channel != "3" || r.Fuzzy {
+		t.Errorf("got %+v, want SANDY/FIRE/3 non-fuzzy", r)
+	}
+}
+
+func TestParseChannelsBackfire(t *testing.T) {
+	results := testParser.ParseChannels("BACKFIRE 2")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Dispatch != "VECC" || r.Separator != "FIRE" || r.Channel != "2" || r.Fuzzy {
+		t.Errorf("got %+v, want VECC/FIRE/2 non-fuzzy", r)
+	}
+}
+
+func TestParseChannelsFuzzy(t *testing.T) {
+	// "CITI" is distance 1 from "CITY"
+	results := testParser.ParseChannels("CITI FIRE 1")
+	if len(results) < 1 {
+		t.Fatalf("expected at least 1 result, got %d", len(results))
+	}
+	found := false
+	for _, r := range results {
+		if r.Dispatch == "CITY" && r.Channel == "1" && r.Fuzzy {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected fuzzy CITY FIRE 1 in results: %+v", results)
+	}
+}
+
+func TestParseChannelsFuzzyFire(t *testing.T) {
+	// "FIRA" is distance 1 from "FIRE" — fuzzy pass should pick it up
+	results := testParser.ParseChannels("CITY FIRA 3")
+	if len(results) < 1 {
+		t.Fatalf("expected at least 1 result for fuzzy separator, got %d", len(results))
+	}
+	found := false
+	for _, r := range results {
+		if r.Dispatch == "CITY" && r.Channel == "3" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CITY/*/3 in results: %+v", results)
+	}
+}
+
+func TestParseChannelsAllDispatches(t *testing.T) {
+	dispatches := []string{"CITY", "VECC", "SANDY"}
+	for _, d := range dispatches {
+		results := testParser.ParseChannels(d + " FIRE 1")
+		if len(results) != 1 {
+			t.Errorf("%s FIRE 1: expected 1 result, got %d", d, len(results))
+			continue
+		}
+		if results[0].Dispatch != d || results[0].Channel != "1" || results[0].Fuzzy {
+			t.Errorf("got %+v, want %s FIRE 1 non-fuzzy", results[0], d)
+		}
+	}
+}
+
+func TestParseChannelsDispatchAliases(t *testing.T) {
+	aliases := []struct {
+		alias string
+		want  string
+	}{
+		{"VEC", "VECC"},
+		{"DECK", "VECC"},
+		{"TECH", "VECC"},
+		{"VAC", "VECC"},
+		{"VEX", "VECC"},
+	}
+	for _, tt := range aliases {
+		results := testParser.ParseChannels(tt.alias + " FIRE 2")
+		if len(results) < 1 {
+			t.Errorf("%s FIRE 2: expected at least 1 result, got 0", tt.alias)
+			continue
+		}
+		found := false
+		for _, r := range results {
+			if r.Dispatch == tt.want && r.Channel == "2" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s FIRE 2: expected dispatch %s in results: %+v", tt.alias, tt.want, results)
+		}
+	}
+}
+
+func TestParseChannelsShorthandDash(t *testing.T) {
+	results := testParser.ParseChannels("SF-3")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for SF-3, got %d", len(results))
+	}
+	if results[0].Dispatch != "SANDY" || results[0].Channel != "3" {
+		t.Errorf("got %+v, want SANDY/FIRE/3", results[0])
+	}
+}
+
+func TestParseChannelsShorthandNoSeparator(t *testing.T) {
+	results := testParser.ParseChannels("SF3")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for SF3, got %d", len(results))
+	}
+	if results[0].Dispatch != "SANDY" || results[0].Channel != "3" {
+		t.Errorf("got %+v, want SANDY/FIRE/3", results[0])
+	}
+}
+
+func TestParseChannelsXFire(t *testing.T) {
+	results := testParser.ParseChannels("X-FIRE 4")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for X-FIRE 4, got %d", len(results))
+	}
+	if results[0].Dispatch != "VECC" || results[0].Channel != "4" {
+		t.Errorf("got %+v, want VECC/FIRE/4", results[0])
+	}
+}
+
+func TestParseChannelsCityAir(t *testing.T) {
+	results := testParser.ParseChannels("CITY AIR 2")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for CITY AIR 2, got %d", len(results))
+	}
+	if results[0].Dispatch != "CITY" || results[0].Channel != "2" {
+		t.Errorf("got %+v, want CITY/FIRE/2", results[0])
+	}
+}
+
+func TestParseChannelsTwoDigit(t *testing.T) {
+	results := testParser.ParseChannels("VECC FIRE 12")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Channel != "12" {
+		t.Errorf("channel = %q, want 12", results[0].Channel)
+	}
+}
+
+func TestParseChannelsThreeDigitIgnored(t *testing.T) {
+	results := testParser.ParseChannels("CITY FIRE 123")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for 3-digit channel, got %d: %+v", len(results), results)
+	}
+}
+
+func TestParseChannelsCaseInsensitive(t *testing.T) {
+	results := testParser.ParseChannels("city fire 3")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for lowercase, got %d", len(results))
+	}
+	if results[0].Dispatch != "CITY" || results[0].Channel != "3" {
+		t.Errorf("got %+v, want CITY FIRE 3", results[0])
+	}
+}
+
+func TestParseChannelsDedup(t *testing.T) {
+	results := testParser.ParseChannels("CITY FIRE 3 AND CITY FIRE 3")
+	if len(results) != 1 {
+		t.Errorf("expected 1 deduped result, got %d", len(results))
+	}
+}
+
+func TestParseChannelsMultiple(t *testing.T) {
+	results := testParser.ParseChannels("CITY FIRE 1 VECC FIRE 2")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestParseChannels_NoNumber(t *testing.T) {
+	results := testParser.ParseChannels("CITY FIRE")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for channel with no number, got %d: %+v", len(results), results)
+	}
+}
+
+// TestParseChannelsOtherSeparator verifies that non-FIRE separators work when configured.
+func TestParseChannelsOtherSeparator(t *testing.T) {
+	p := NewTranscriptParser(TranscriptConfig{
+		DispatchNames: []FuzzyWord{
+			{Word: "METRO", MaxDistance: 1},
+			{Word: "COUNTY", MaxDistance: 1},
+		},
+		ChannelSeparators: []FuzzyWord{
+			{Word: "POLICE", MaxDistance: 1},
+			{Word: "EMS", MaxDistance: 0},
+			{Word: "OPS", MaxDistance: 0},
+		},
+	})
+
+	tests := []struct {
+		input    string
+		dispatch string
+		sep      string
+		channel  string
+	}{
+		{"METRO POLICE 2", "METRO", "POLICE", "2"},
+		{"COUNTY EMS 1", "COUNTY", "EMS", "1"},
+		{"METRO OPS 5", "METRO", "OPS", "5"},
+	}
+	for _, tt := range tests {
+		results := p.ParseChannels(tt.input)
+		if len(results) != 1 {
+			t.Errorf("%q: expected 1 result, got %d", tt.input, len(results))
+			continue
+		}
+		r := results[0]
+		if r.Dispatch != tt.dispatch || r.Separator != tt.sep || r.Channel != tt.channel {
+			t.Errorf("%q: got %+v, want dispatch=%s sep=%s channel=%s", tt.input, r, tt.dispatch, tt.sep, tt.channel)
+		}
+	}
+}
+
+// TestParseChannelsNoSeparator verifies that {Dispatch} {Number} matching works
+// when no ChannelSeparators are configured.
+func TestParseChannelsNoSeparator(t *testing.T) {
+	p := NewTranscriptParser(TranscriptConfig{
+		DispatchNames: []FuzzyWord{
+			{Word: "ALPHA", MaxDistance: 0},
+			{Word: "BRAVO", MaxDistance: 0},
+		},
+	})
+
+	results := p.ParseChannels("ALPHA 3 AND BRAVO 7")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d: %+v", len(results), results)
+	}
+	if results[0].Dispatch != "ALPHA" || results[0].Separator != "" || results[0].Channel != "3" {
+		t.Errorf("result[0] = %+v, want ALPHA/3", results[0])
+	}
+	if results[1].Dispatch != "BRAVO" || results[1].Separator != "" || results[1].Channel != "7" {
+		t.Errorf("result[1] = %+v, want BRAVO/7", results[1])
+	}
+}
+
+// TestParseChannelsSeparatorPopulatedOnFuzzy verifies that the Separator field is
+// set correctly on fuzzy (Pass 2) matches, not just exact (Pass 1) matches.
+func TestParseChannelsSeparatorPopulatedOnFuzzy(t *testing.T) {
+	// "CITI" is a fuzzy match for "CITY" — result should still carry Separator "FIRE"
+	results := testParser.ParseChannels("CITI FIRE 2")
+	if len(results) < 1 {
+		t.Fatalf("expected at least 1 result, got 0")
+	}
+	for _, r := range results {
+		if r.Dispatch == "CITY" && r.Channel == "2" {
+			if r.Separator != "FIRE" {
+				t.Errorf("fuzzy match: separator = %q, want FIRE", r.Separator)
+			}
+			return
+		}
+	}
+	t.Errorf("expected CITY/FIRE/2 in results: %+v", results)
+}
+
+// --- CorrectTranscript ---
+
+func TestCorrectTranscriptEmpty(t *testing.T) {
+	result := testParser.CorrectTranscript("")
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestCorrectTranscriptNoMatch(t *testing.T) {
+	// Input that contains none of the configured corrections should pass through unchanged.
+	input := "SOME RANDOM TRANSCRIPT"
+	result := testParser.CorrectTranscript(input)
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestCorrectTranscriptWithCorrections(t *testing.T) {
+	p := NewTranscriptParser(TranscriptConfig{
+		Corrections: []FuzzyWord{
+			{Word: "DISPATCH", MaxDistance: 2, Aliases: []string{"DISPACH"}},
+			{Word: "RESPOND", MaxDistance: 0, Aliases: []string{"RSPOND", "RESPND"}},
+			{Word: "STROKE OR CVA", MaxDistance: 1},
+		},
+	})
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"exact alias", "DISPACH TO SCENE", "DISPATCH TO SCENE"},
+		{"fuzzy match", "DISPATC TO SCENE", "DISPATCH TO SCENE"},
+		{"multiple corrections", "DISPACH AND RESPND", "DISPATCH AND RESPOND"},
+		{"no match passthrough", "ENGINE 5 RESPONDING", "ENGINE 5 RESPONDING"},
+		{"alias case insensitive", "rspond to call", "RESPOND TO CALL"},
+		{"stroke or cva 1", "RESPOND TO STROKE OR CPA", "RESPOND TO STROKE OR CVA"},
+		{"stroke or cva 2", "RESPOND TO STROKE OR CDA", "RESPOND TO STROKE OR CVA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.CorrectTranscript(tt.input)
+			if got != tt.want {
+				t.Errorf("CorrectTranscript(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCorrectTranscriptMultiWord(t *testing.T) {
+	p := NewTranscriptParser(TranscriptConfig{
+		Corrections: []FuzzyWord{
+			{Word: "SHORT FALL", MaxDistance: 2, Aliases: []string{"SHEFFIELD", "SHORTFALL"}},
+			{Word: "UNKNOWN MEDICAL", MaxDistance: 1, Aliases: []string{"A KNOWN MEDICAL"}},
+		},
+	})
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"multi-word alias", "SHEFFIELD IS ON SCENE", "SHORT FALL IS ON SCENE"},
+		{"single word alias", "RESPOND TO SHORTFALL", "RESPOND TO SHORT FALL"},
+		{"multi-word fuzzy", "SHORT FAL RESPONDING", "SHORT FALL RESPONDING"},
+		{"multi-word alias with spaces", "A KNOWN MEDICAL EMERGENCY", "UNKNOWN MEDICAL EMERGENCY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.CorrectTranscript(tt.input)
+			if got != tt.want {
+				t.Errorf("CorrectTranscript(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- ParseTranscript (combined) ---
+
+func TestParseTranscript_Empty(t *testing.T) {
+	units, channels := testParser.ParseTranscript("")
+	if units == nil {
+		t.Error("ParseTranscript units = nil, want empty slice")
+	}
+	if channels == nil {
+		t.Error("ParseTranscript channels = nil, want empty slice")
+	}
+	if len(units) != 0 {
+		t.Errorf("ParseTranscript units len = %d, want 0", len(units))
+	}
+	if len(channels) != 0 {
+		t.Errorf("ParseTranscript channels len = %d, want 0", len(channels))
+	}
+}
+
+func TestParseTranscriptIntegration(t *testing.T) {
+	units, channels := testParser.ParseTranscript("ENGINE 5 RESPONDING ON CITY FIRE 3")
+
+	if len(units) != 1 {
+		t.Fatalf("expected 1 unit, got %d", len(units))
+	}
+	if units[0].Apparatus != "ENGINE" || units[0].Number != "5" {
+		t.Errorf("unit = %+v, want ENGINE 5", units[0])
+	}
+
+	if len(channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(channels))
+	}
+	if channels[0].Dispatch != "CITY" || channels[0].Channel != "3" {
+		t.Errorf("channel = %+v, want CITY FIRE 3", channels[0])
+	}
+}
+
+func TestParseTranscriptMultipleUnitsAndChannels(t *testing.T) {
+	units, channels := testParser.ParseTranscript("ENGINE 5 TRUCK 3 RESPONDING ON VECC FIRE 2 AND CITY FIRE 1")
+	if len(units) != 2 {
+		t.Fatalf("expected 2 units, got %d", len(units))
+	}
+	if len(channels) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(channels))
+	}
+}
+
+func TestParseTranscriptFuzzyUnitsAndChannels(t *testing.T) {
+	units, channels := testParser.ParseTranscript("ENGNE 5 RESPONDING ON CITI FIRE 3")
+
+	if len(units) != 1 {
+		t.Fatalf("expected 1 unit, got %d", len(units))
+	}
+	if units[0].Apparatus != "ENGINE" || !units[0].Fuzzy {
+		t.Errorf("unit = %+v, want fuzzy ENGINE 5", units[0])
+	}
+
+	if len(channels) < 1 {
+		t.Fatalf("expected at least 1 channel, got %d", len(channels))
+	}
+	found := false
+	for _, c := range channels {
+		if c.Dispatch == "CITY" && c.Channel == "3" && c.Fuzzy {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected fuzzy CITY FIRE 3 in channels: %+v", channels)
+	}
+}
+
+func TestParseTranscriptShorthandWithUnits(t *testing.T) {
+	units, channels := testParser.ParseTranscript("ENGINE 1 RESPONDING SF 3")
+	if len(units) != 1 {
+		t.Fatalf("expected 1 unit, got %d", len(units))
+	}
+	if len(channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(channels))
+	}
+	if channels[0].Dispatch != "SANDY" || channels[0].Channel != "3" {
+		t.Errorf("channel = %+v, want SANDY/FIRE/3", channels[0])
+	}
+}

--- a/server/transcript_parser_test.go
+++ b/server/transcript_parser_test.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -944,5 +945,151 @@ func TestParseTranscriptShorthandWithUnits(t *testing.T) {
 	}
 	if channels[0].Dispatch != "SANDY" || channels[0].Channel != "3" {
 		t.Errorf("channel = %+v, want SANDY/FIRE/3", channels[0])
+	}
+}
+
+// --- AnnotateTranscript ---
+
+func TestAnnotateTranscriptBasic(t *testing.T) {
+	corrected, annotations := testParser.AnnotateTranscript("ENGINE 5 RESPONDING ON CITY FIRE 3")
+	if corrected == "" {
+		t.Fatal("expected non-empty corrected string")
+	}
+	if len(annotations) != 2 {
+		t.Fatalf("expected 2 annotations (1 unit + 1 channel), got %d: %+v", len(annotations), annotations)
+	}
+
+	unitAnn := annotations[0]
+	if unitAnn.Type != "unit" || unitAnn.Apparatus != "ENGINE" || unitAnn.Number != "5" {
+		t.Errorf("annotation[0] = %+v, want unit ENGINE 5", unitAnn)
+	}
+	if unitAnn.Start < 0 || unitAnn.End <= unitAnn.Start {
+		t.Errorf("unit annotation has invalid offsets: start=%d end=%d", unitAnn.Start, unitAnn.End)
+	}
+	if corrected[unitAnn.Start:unitAnn.End] != unitAnn.Text {
+		t.Errorf("unit annotation text %q does not match corrected[%d:%d] = %q",
+			unitAnn.Text, unitAnn.Start, unitAnn.End, corrected[unitAnn.Start:unitAnn.End])
+	}
+
+	chanAnn := annotations[1]
+	if chanAnn.Type != "channel" || chanAnn.Dispatch != "CITY" || chanAnn.Channel != "3" {
+		t.Errorf("annotation[1] = %+v, want channel CITY/FIRE/3", chanAnn)
+	}
+	if corrected[chanAnn.Start:chanAnn.End] != chanAnn.Text {
+		t.Errorf("channel annotation text %q does not match corrected[%d:%d] = %q",
+			chanAnn.Text, chanAnn.Start, chanAnn.End, corrected[chanAnn.Start:chanAnn.End])
+	}
+}
+
+func TestAnnotateTranscriptFuzzy(t *testing.T) {
+	// "ENGNE" is fuzzy ENGINE; "CITI" is fuzzy CITY
+	_, annotations := testParser.AnnotateTranscript("ENGNE 5 ON CITI FIRE 3")
+	if len(annotations) < 2 {
+		t.Fatalf("expected at least 2 annotations, got %d: %+v", len(annotations), annotations)
+	}
+
+	var unitAnn, chanAnn *TranscriptAnnotation
+	for i := range annotations {
+		switch annotations[i].Type {
+		case "unit":
+			unitAnn = &annotations[i]
+		case "channel":
+			chanAnn = &annotations[i]
+		}
+	}
+
+	if unitAnn == nil {
+		t.Fatal("no unit annotation found")
+	}
+	if !unitAnn.Fuzzy || unitAnn.Apparatus != "ENGINE" {
+		t.Errorf("unit annotation = %+v, want fuzzy ENGINE", unitAnn)
+	}
+
+	if chanAnn == nil {
+		t.Fatal("no channel annotation found")
+	}
+	if !chanAnn.Fuzzy || chanAnn.Dispatch != "CITY" {
+		t.Errorf("channel annotation = %+v, want fuzzy CITY", chanAnn)
+	}
+}
+
+func TestAnnotateTranscriptCorrections(t *testing.T) {
+	// "A KNOWN MEDICAL" should be corrected to "UNKNOWN MEDICAL" before parsing
+	p := NewTranscriptParser(TranscriptConfig{
+		Corrections: []FuzzyWord{
+			{Word: "UNKNOWN MEDICAL", MaxDistance: 1, Aliases: []string{"A KNOWN MEDICAL"}},
+		},
+		UnitTypes: []FuzzyWord{
+			{Word: "ENGINE", MaxDistance: 1},
+		},
+	})
+
+	corrected, _ := p.AnnotateTranscript("a known medical ENGINE 5")
+	if !strings.Contains(corrected, "UNKNOWN MEDICAL") {
+		t.Errorf("expected correction in output, got %q", corrected)
+	}
+	if strings.Contains(corrected, "A KNOWN MEDICAL") {
+		t.Errorf("expected original mis-transcription to be corrected, got %q", corrected)
+	}
+
+	// Annotation offsets must reference the corrected string, not the original
+	_, annotations := p.AnnotateTranscript("a known medical ENGINE 5")
+	for _, ann := range annotations {
+		if ann.Type == "unit" {
+			if corrected[ann.Start:ann.End] != ann.Text {
+				t.Errorf("annotation offset mismatch: corrected[%d:%d]=%q but Text=%q",
+					ann.Start, ann.End, corrected[ann.Start:ann.End], ann.Text)
+			}
+		}
+	}
+}
+
+func TestAnnotateTranscriptEmpty(t *testing.T) {
+	corrected, annotations := testParser.AnnotateTranscript("")
+	if corrected != "" {
+		t.Errorf("expected empty corrected string, got %q", corrected)
+	}
+	if annotations != nil {
+		t.Errorf("expected nil annotations for empty input, got %v", annotations)
+	}
+}
+
+func TestAnnotateTranscriptNoParser(t *testing.T) {
+	var p *TranscriptParser
+	corrected, annotations := p.AnnotateTranscript("ENGINE 5 RESPONDING")
+	if corrected != "ENGINE 5 RESPONDING" {
+		t.Errorf("nil parser should pass transcript through, got %q", corrected)
+	}
+	if annotations != nil {
+		t.Errorf("nil parser should return nil annotations, got %v", annotations)
+	}
+}
+
+func TestAnnotateTranscriptSortedByStart(t *testing.T) {
+	// Two units: ENGINE 5 at start, LADDER 3 later — annotations must be in order
+	corrected, annotations := testParser.AnnotateTranscript("ENGINE 5 AND LADDER 3")
+	if len(annotations) != 2 {
+		t.Fatalf("expected 2 annotations, got %d: %+v", len(annotations), annotations)
+	}
+	if annotations[0].Start > annotations[1].Start {
+		t.Errorf("annotations not sorted: [0].Start=%d [1].Start=%d", annotations[0].Start, annotations[1].Start)
+	}
+	// Verify offsets are correct
+	for i, ann := range annotations {
+		if corrected[ann.Start:ann.End] != ann.Text {
+			t.Errorf("annotation[%d] offset mismatch: corrected[%d:%d]=%q Text=%q",
+				i, ann.Start, ann.End, corrected[ann.Start:ann.End], ann.Text)
+		}
+	}
+}
+
+func TestAnnotateTranscriptNoMatches(t *testing.T) {
+	// A transcript with no recognizable units or channels returns nil annotations
+	corrected, annotations := testParser.AnnotateTranscript("RESPOND TO THE SCENE IMMEDIATELY")
+	if corrected == "" {
+		t.Error("corrected string should not be empty")
+	}
+	if annotations != nil {
+		t.Errorf("expected nil annotations when nothing recognized, got %v", annotations)
 	}
 }


### PR DESCRIPTION
Linked issue: #180 

**Summary**

- Adds a configurable transcript parser that identifies apparatus units (e.g., ENGINE 5, MEDIC LADDER 3) and dispatch channels (e.g,. VECC FIRE 3) in call transcripts using fuzzy/alias matching
- Server applies corrections and canonical substitutions before returning transcripts, so all consumers (UI, alerts, API clients) see clean, normalized text
- Frontend renders highlighted spans over recognized units (blue) and channels (green) in all transcript display locations: now-playing, call detail, alerts tab, and transcripts tab
- New Admin Transcript Parser config panel for managing word lists

**What's included**

**Server (transcript_parser.go, admin.go, api.go, call.go, controller.go, options.go):**

- TranscriptConfig: configurable word lists: unit types, unit prefixes, dispatch names, channel separators, channel shorthands, corrections
- Fuzzy matching via Levenshtein distance, alias matching, and reject-list support
- AnnotateTranscript: applies corrections, parses units/channels, substitutes canonical forms, converts byte offsets to Unicode rune offsets for JS compatibility
- GET/PUT /api/admin/transcript-parser: load and save config; rebuilds active parser on save
- transcriptAnnotations field added to all call/alert/transcript API responses

**Frontend:**

- transcript-utils.ts: shared renderAnnotatedTranscript() utility combining annotation spans and search highlighting
- transcript-parser admin component: full CRUD UI with inline editing, alias/reject chips, and collapsible documentation
- Annotation styles applied via ::ng-deep to reach [innerHTML]-injected spans

**Future**

Possibly combine this with the Hallucination Pattern feature. 

**Preview**

<img width="1445" height="1025" alt="Screenshot_20260414_032745" src="https://github.com/user-attachments/assets/8c5dabe2-3cc1-440d-bea3-3fa078441e66" />
<img width="1447" height="1041" alt="Screenshot_20260414_032826" src="https://github.com/user-attachments/assets/4f616a9f-3e33-4cc8-a259-9665c3baf818" />
<img width="1371" height="907" alt="Screenshot_20260414_033040" src="https://github.com/user-attachments/assets/96bcc8bc-c519-4477-92c2-c921037115d5" />
<img width="288" height="438" alt="Screenshot_20260414_033025" src="https://github.com/user-attachments/assets/9d1c06fb-16a2-4e52-8610-94085475f1ed" />