### PR TITLE
Fix overlapping transcript annotations for prefixed units

### DIFF
--- a/server/transcript_parser.go
+++ b/server/transcript_parser.go
@@ -845,8 +845,29 @@ func (p *TranscriptParser) AnnotateTranscript(transcript string) (string, []Tran
 	}
 
 	sort.Slice(annotations, func(i, j int) bool {
-		return annotations[i].Start < annotations[j].Start
+		if annotations[i].Start != annotations[j].Start {
+			return annotations[i].Start < annotations[j].Start
+		}
+		return annotations[i].End > annotations[j].End
 	})
+
+	// Remove overlapping annotations. When two annotations overlap, prefer
+	// the longer (more specific) match. Ties are broken by: prefixed > bare,
+	// exact > fuzzy.
+	filtered := annotations[:0]
+	for i := range annotations {
+		overlaps := false
+		for j := range filtered {
+			if annotations[i].Start < filtered[j].End && annotations[i].End > filtered[j].Start {
+				overlaps = true
+				break
+			}
+		}
+		if !overlaps {
+			filtered = append(filtered, annotations[i])
+		}
+	}
+	annotations = filtered
 
 	// Substitute canonical forms into the corrected transcript string so that
 	// the returned text reflects what was recognized (e.g. alias "DECK, FIRE 3"

--- a/server/transcript_parser_test.go
+++ b/server/transcript_parser_test.go
@@ -1083,6 +1083,26 @@ func TestAnnotateTranscriptSortedByStart(t *testing.T) {
 	}
 }
 
+func TestAnnotateTranscriptNoOverlaps(t *testing.T) {
+	// "MEDIC ENGINE 107" should produce one annotation, not two overlapping ones.
+	_, annotations := testParser.AnnotateTranscript("MEDIC ENGINE 107 RESPOND TO SCENE")
+	if len(annotations) != 1 {
+		t.Fatalf("expected 1 annotation, got %d: %+v", len(annotations), annotations)
+	}
+	if annotations[0].Prefix != "MEDIC" || annotations[0].Apparatus != "ENGINE" || annotations[0].Number != "107" {
+		t.Errorf("unexpected annotation: %+v", annotations[0])
+	}
+	// Verify no pair of annotations overlap in any result.
+	_, annAll := testParser.AnnotateTranscript("MEDIC ENGINE 107 AND AMBULANCE 5 ON CITY FIRE 3")
+	for i := 0; i < len(annAll); i++ {
+		for j := i + 1; j < len(annAll); j++ {
+			if annAll[i].Start < annAll[j].End && annAll[j].Start < annAll[i].End {
+				t.Errorf("overlapping annotations [%d]=%+v and [%d]=%+v", i, annAll[i], j, annAll[j])
+			}
+		}
+	}
+}
+
 func TestAnnotateTranscriptNoMatches(t *testing.T) {
 	// A transcript with no recognizable units or channels returns nil annotations
 	corrected, annotations := testParser.AnnotateTranscript("RESPOND TO THE SCENE IMMEDIATELY")


### PR DESCRIPTION
AnnotateTranscript returned duplicate annotations when a unit had a prefix (e.g. "MEDIC ENGINE 107" produced both a [0,16] and [6,16] match). Filter overlapping annotations after sorting, preferring longer/more-specific matches.