### PR TITLE
Add GHCR publish workflow and configure tagging logic

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -87,4 +87,3 @@ jobs:
         if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Build and Publish to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase repository name
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
 This PR adds a new GitHub Actions workflow to build and publish Docker containers to GHCR.io.

  Key Features:
   - New Workflow: .github/workflows/publish.yml
   - Triggers: Runs on pushes to main, tags matching v*, and all pull requests to main.
   - Authentication: Uses secrets.GITHUB_TOKEN to log into ghcr.io.
   - GHCR Compatibility: Automatically lowercases the image name for compatibility.
   - Tagging Logic:
       - Pushes to main are tagged as main.
       - The latest tag is only applied when a version tag (e.g., v1.0.0) is pushed.
       - Full SemVer support (e.g., v1.2.3 generates 1.2.3 and 1.2).
   - Optimization: Uses docker/build-push-action with gha caching for faster builds.
   - Safety: Push is disabled for pull requests to prevent unauthorized registry writes.

  The existing docker-build.yml (Docker Hub) has been preserved and remains unaffected by these changes.
