### PR TITLE
Play dispatch audio from learned tone patterns (name A/B pairs by ear)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log
 
+## Unreleased
+
+### Added
+
+- **Learned tone patterns — play dispatch audio**
+  - In **Systems → Talkgroups → Analyze tone history**, each learned tone pattern (e.g. a learned A/B pair) now has a **play/stop** control on its transcript samples so an operator can hear the dispatch tone-out and name the tone set correctly before adding it.
+  - Patterns whose calls have no transcript (tone-only) get a single **Play dispatch audio** button that plays a representative call.
+  - Audio streams from the existing admin `/api/admin/call-audio/{callId}` endpoint; playback stops automatically when re-analyzing, adding the tone set, or leaving the editor.
+
+---
+
 ## Version 26.07.23 - Released July 20, 2026
 
 ### Fixed

--- a/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.html
@@ -266,10 +266,27 @@
                     <div style="font-weight: 600; margin-bottom: 4px;">{{ suggestion.label }}</div>
                     <div class="mat-caption" style="color: #aaa; margin-bottom: 8px;">{{ suggestion.patternDesc }} · {{ suggestion.callCount }} calls</div>
                     <div *ngIf="suggestion.samples?.length" style="margin-bottom: 8px;">
-                        <div class="mat-caption" style="color: #888; margin-bottom: 4px;">Transcripts from matching calls:</div>
-                        <div *ngFor="let sample of suggestion.samples" class="mat-caption"
-                             style="color: #bbb; margin-bottom: 4px; padding: 4px 8px; background: rgba(255,255,255,0.03); border-left: 2px solid rgba(255,255,255,0.15); border-radius: 2px;">
-                            "{{ sample.transcript }}"
+                        <div class="mat-caption" style="color: #888; margin-bottom: 4px;">Play the dispatch audio to hear the tone-out and name this tone set:</div>
+                        <div *ngFor="let sample of suggestion.samples" class="tone-sample-row">
+                            <button type="button" mat-icon-button class="tone-sample-play"
+                                    [color]="isToneSamplePlaying(sample.callId) ? 'warn' : 'primary'"
+                                    [matTooltip]="isToneSamplePlaying(sample.callId) ? 'Stop audio' : 'Play dispatch audio'"
+                                    [attr.aria-label]="isToneSamplePlaying(sample.callId) ? 'Stop audio' : 'Play dispatch audio'"
+                                    (click)="playToneSampleAudio(sample.callId)">
+                                <mat-icon>{{ isToneSamplePlaying(sample.callId) ? 'stop' : 'play_arrow' }}</mat-icon>
+                            </button>
+                            <span class="mat-caption tone-sample-transcript">"{{ sample.transcript }}"</span>
+                        </div>
+                    </div>
+                    <div *ngIf="!suggestion.samples?.length && suggestion.callIds?.length" style="margin-bottom: 8px;">
+                        <button type="button" mat-stroked-button
+                                [color]="isToneSamplePlaying(suggestion.callIds[0]) ? 'warn' : 'accent'"
+                                (click)="playToneSampleAudio(suggestion.callIds[0])">
+                            <mat-icon>{{ isToneSamplePlaying(suggestion.callIds[0]) ? 'stop' : 'play_arrow' }}</mat-icon>
+                            {{ isToneSamplePlaying(suggestion.callIds[0]) ? 'Stop audio' : 'Play dispatch audio' }}
+                        </button>
+                        <div class="mat-caption" style="color: #888; margin-top: 4px;">
+                            No transcripts on these calls — play a sample to hear the tone-out.
                         </div>
                     </div>
                     <button type="button" mat-stroked-button color="primary" (click)="addSuggestedToneSet(suggestion)">

--- a/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.scss
@@ -1,3 +1,27 @@
+// ─── Learned tone pattern: play dispatch audio per transcript sample ─────────
+.tone-sample-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.tone-sample-play {
+    flex: 0 0 auto;
+    // Nudge the small icon button in line with the first line of transcript text.
+    margin-top: -2px;
+}
+
+.tone-sample-transcript {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: #bbb;
+    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.03);
+    border-left: 2px solid rgba(255, 255, 255, 0.15);
+    border-radius: 2px;
+}
+
 // ─── Warning card ─────────────────────────────────────────────────────────────
 .warn-card {
     background: rgba(255, 87, 34, 0.08);

--- a/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.ts
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, NgZone, OnDestroy, Output, ViewChild } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatSelectChange } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -31,7 +31,7 @@ import { RdioScannerToneSet } from '../../../../rdio-scanner';
     styleUrls: ['./talkgroup.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RdioScannerAdminTalkgroupComponent {
+export class RdioScannerAdminTalkgroupComponent implements OnDestroy {
     @Input() form: FormGroup | undefined;
     @Input() groups: Group[] = [];
     @Input() tags: Tag[] = [];
@@ -71,12 +71,116 @@ export class RdioScannerAdminTalkgroupComponent {
         return typeof id === 'number' && id > 0 ? id : undefined;
     }
 
+    // Playback of the dispatch audio behind a learned tone pattern, so the
+    // operator can hear the tone-out and name the tone set correctly.
+    playingToneCallId: number | null = null;
+    private toneAudioElement: HTMLAudioElement | null = null;
+    // Object URL backing the current playback; revoked whenever playback stops.
+    private toneAudioUrl: string | null = null;
+    // Monotonic token: a newer play (or stop) invalidates any in-flight fetch.
+    private toneAudioReq = 0;
+
     constructor(
         private adminService: RdioScannerAdminService,
         private cdr: ChangeDetectorRef,
         private formBuilder: FormBuilder,
         private snackBar: MatSnackBar,
+        private ngZone: NgZone,
     ) {
+    }
+
+    ngOnDestroy(): void {
+        this.stopToneAudio();
+    }
+
+    /**
+     * Play (or stop, if already playing) the dispatch audio for one of the calls
+     * behind a learned tone pattern. Fetches with the admin token and plays via a
+     * blob URL, mirroring the system-health call playback.
+     */
+    async playToneSampleAudio(callId: number | undefined): Promise<void> {
+        if (!callId) {
+            return;
+        }
+        if (this.playingToneCallId === callId) {
+            this.ngZone.run(() => {
+                this.stopToneAudio();
+                this.cdr.markForCheck();
+            });
+            return;
+        }
+        this.stopToneAudio();
+        const reqId = ++this.toneAudioReq;
+        try {
+            const response = await fetch(this.adminService.getCallAudioUrl(callId), {
+                headers: this.adminService.getFetchHeaders(),
+            });
+            if (reqId !== this.toneAudioReq) {
+                return; // superseded by a newer play/stop
+            }
+            if (!response.ok) {
+                throw new Error(`audio request failed (${response.status})`);
+            }
+            const blobUrl = URL.createObjectURL(await response.blob());
+            if (reqId !== this.toneAudioReq) {
+                URL.revokeObjectURL(blobUrl);
+                return;
+            }
+            const audio = new Audio(blobUrl);
+            // The fetch/decode continuation may resume outside Angular's zone, so
+            // run the state mutations inside it to guarantee the OnPush view (the
+            // play/stop icon) refreshes deterministically.
+            const finish = () => {
+                // Only the current playback tears down; a superseded one was
+                // already stopped (and its URL revoked) by stopToneAudio().
+                if (this.toneAudioElement === audio) {
+                    this.ngZone.run(() => {
+                        this.stopToneAudio();
+                        this.cdr.markForCheck();
+                    });
+                }
+            };
+            audio.onended = finish;
+            audio.onerror = () => {
+                finish();
+                this.snackBar.open('Failed to play call audio', '', { duration: 4000 });
+            };
+            this.ngZone.run(() => {
+                this.toneAudioElement = audio;
+                this.toneAudioUrl = blobUrl;
+                this.playingToneCallId = callId;
+                this.cdr.markForCheck();
+            });
+            await audio.play();
+        } catch {
+            if (reqId === this.toneAudioReq) {
+                this.ngZone.run(() => {
+                    this.stopToneAudio();
+                    this.snackBar.open('Failed to play call audio', '', { duration: 4000 });
+                    this.cdr.markForCheck();
+                });
+            }
+        }
+    }
+
+    isToneSamplePlaying(callId: number | undefined): boolean {
+        return !!callId && this.playingToneCallId === callId;
+    }
+
+    private stopToneAudio(): void {
+        // Bump the token so any in-flight fetch aborts when it resolves.
+        this.toneAudioReq++;
+        if (this.toneAudioElement) {
+            this.toneAudioElement.onended = null;
+            this.toneAudioElement.onerror = null;
+            this.toneAudioElement.pause();
+            this.toneAudioElement = null;
+        }
+        if (this.toneAudioUrl) {
+            URL.revokeObjectURL(this.toneAudioUrl);
+            this.toneAudioUrl = null;
+        }
+        this.playingToneCallId = null;
     }
 
     getToneSets(): FormArray {
@@ -307,6 +411,7 @@ export class RdioScannerAdminTalkgroupComponent {
             return;
         }
 
+        this.stopToneAudio();
         this.analyzingToneHistory = true;
         this.toneHistoryComplete = false;
         this.toneHistoryError = false;
@@ -363,8 +468,20 @@ export class RdioScannerAdminTalkgroupComponent {
             ...suggestion.toneSet,
             label: suggestion.label || suggestion.toneSet.label,
         }, true);
+        // Stop playback if it belonged to the suggestion we just consumed.
+        if (this.isSuggestionCallId(suggestion, this.playingToneCallId)) {
+            this.stopToneAudio();
+        }
         this.toneHistorySuggestions = this.toneHistorySuggestions.filter((s) => s !== suggestion);
         this.cdr.markForCheck();
+    }
+
+    private isSuggestionCallId(suggestion: ToneHistorySuggestion, callId: number | null): boolean {
+        if (!callId) {
+            return false;
+        }
+        return (suggestion.callIds || []).includes(callId) ||
+            (suggestion.samples || []).some((s) => s.callId === callId);
     }
 
     private appendImportedToneSets(toneSets: RdioScannerToneSet[]): void {


### PR DESCRIPTION
## Summary

Addresses the request to **jump to the dispatch audio for a learned tone pattern (learned A/B pair) so it can be named correctly**.

In **Admin Systems Talkgroups Analyze tone history**, each learned tone pattern now lets the operator play the dispatch audio of the calls that produced it, so they can hear the tone-out and pick the right tone-set name before adding it.

## What changed

- Each transcript sample under a learned pattern gets a **play / stop** icon button. Clicking plays that call's audio; clicking again (or starting another) stops it.
- Patterns whose calls have **no transcript** (tone-only) show a single **Play dispatch audio** button that plays a representative call (`callIds[0]`), with a caption explaining there are no transcripts.
- The button reflects state: `play_arrow`  `stop`, with matching tooltip/aria-label.

## Implementation notes

- **Client-only.** No server changes it reuses the existing admin `GET /api/admin/call-audio/{callId}` endpoint (admin-token auth), fetching the blob with `getFetchHeaders()` and playing it via an object URL. This mirrors the existing, working playback in `system-health.component.ts`.
- The server already returns everything needed: `ToneHistorySuggestion.samples[]` carries `{ callId, transcript }`, and `callIds[]` carries every call in the pattern.
- Playback is cleaned up on **re-analyze**, **add tone set**, and **component destroy**; a monotonic request token invalidates in-flight fetches when a newer play/stop happens, and object URLs are revoked on every path.
- State mutations after the async fetch run inside Angular's zone so the OnPush play/stop icon updates deterministically.

## Testing

Verified end-to-end against a local Postgres + server build:

- Injected a learned-pattern suggestion into the running talkgroup editor and confirmed the **play button renders** next to the transcript sample.
- Clicking it issues `GET /api/admin/call-audio/{callId}` **200** and plays the audio (valid `audio/wav` blob).
- The icon toggles **`play_arrow` `stop` `play_arrow`** in sync with playback state, in both directions, with no console errors.
- Client builds clean under production AOT.
