### PR TITLE
Multiple subscription tiers (multi-group public registration)

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/admin.service.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.service.ts
@@ -137,6 +137,7 @@ export interface User {
     forcePasswordReset?: boolean;
     isGroupAdmin?: boolean;
     userGroupId?: number;
+    userGroupIds?: number[];
     connectionLimit?: number;
     delay?: number;
     zipCode?: string;
@@ -1700,6 +1701,7 @@ export class RdioScannerAdminService implements OnDestroy {
             forcePasswordReset: this.ngFormBuilder.control(user?.forcePasswordReset),
             isGroupAdmin: this.ngFormBuilder.control(user?.isGroupAdmin),
             userGroupId: this.ngFormBuilder.control(user?.userGroupId),
+            userGroupIds: this.ngFormBuilder.control(user?.userGroupIds || (user?.userGroupId ? [user.userGroupId] : [])),
             connectionLimit: this.ngFormBuilder.control(user?.connectionLimit),
             delay: this.ngFormBuilder.control(user?.delay),
             zipCode: this.ngFormBuilder.control(user?.zipCode || ''),

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
@@ -287,14 +287,26 @@
 
                             <div class="form-row">
                                 <mat-form-field appearance="outline" class="full-width">
-                                    <mat-label>User Group</mat-label>
+                                    <mat-label>Primary Group</mat-label>
                                     <mat-select formControlName="userGroupId">
                                         <mat-option [value]="0">No Group (Unassigned)</mat-option>
                                         <mat-option *ngFor="let group of availableGroups" [value]="group.id">
                                             {{ group.name }}
                                         </mat-option>
                                     </mat-select>
-                                    <mat-hint>Assign to a group to inherit group settings</mat-hint>
+                                    <mat-hint>Home group (group-admin role, invitation default)</mat-hint>
+                                </mat-form-field>
+                            </div>
+
+                            <div class="form-row">
+                                <mat-form-field appearance="outline" class="full-width">
+                                    <mat-label>Group Memberships</mat-label>
+                                    <mat-select formControlName="userGroupIds" multiple>
+                                        <mat-option *ngFor="let group of availableGroups" [value]="group.id">
+                                            {{ group.name }}
+                                        </mat-option>
+                                    </mat-select>
+                                    <mat-hint>All groups this user belongs to — access is the union. The primary group is always included.</mat-hint>
                                 </mat-form-field>
                             </div>
 

--- a/client/src/app/components/rdio-scanner/settings/settings.component.html
+++ b/client/src/app/components/rdio-scanner/settings/settings.component.html
@@ -556,6 +556,54 @@
             </div>
         </div>
 
+        <div class="section tiers-section" *ngIf="accountInfo?.memberships?.length || accountInfo?.availableTiers?.length">
+            <h3>Your Tiers</h3>
+            <p class="section-description">
+                The subscription tiers you belong to. Add or remove tiers to change which systems you can access — paid changes are billed automatically.
+            </p>
+
+            <div class="tier-list">
+                <div class="tier-row" *ngFor="let m of accountInfo.memberships">
+                    <div class="tier-main">
+                        <span class="tier-name">{{ m.name }}</span>
+                        <span class="tier-badge tier-badge--primary" *ngIf="m.isPrimary">Primary</span>
+                        <span class="tier-badge tier-badge--paid" *ngIf="m.paid">Paid</span>
+                        <span class="tier-badge tier-badge--warn" *ngIf="m.billingEnabled && !m.paid">Unpaid</span>
+                        <span class="tier-badge" *ngIf="!m.billingEnabled">Free</span>
+                    </div>
+                    <button mat-button color="warn"
+                            *ngIf="m.selfBillable && !(m.isPrimary && accountInfo.memberships.length <= 1)"
+                            (click)="removeTier(m.groupId)">
+                        <mat-icon>remove_circle_outline</mat-icon>
+                        Remove
+                    </button>
+                </div>
+            </div>
+
+            <div class="add-tier" *ngIf="accountInfo.availableTiers?.length">
+                <h4>Add a tier</h4>
+                <div class="tier-row" *ngFor="let t of accountInfo.availableTiers">
+                    <div class="tier-main">
+                        <span class="tier-name">{{ t.name }}</span>
+                        <span class="tier-desc" *ngIf="t.description">{{ t.description }}</span>
+                    </div>
+                    <div class="add-tier-controls">
+                        <select *ngIf="t.billingEnabled && t.pricingOptions?.length"
+                                [(ngModel)]="selectedTierPrice[t.groupId]">
+                            <option [ngValue]="undefined" disabled>Select a plan…</option>
+                            <option *ngFor="let o of t.pricingOptions" [ngValue]="o.priceId">{{ o.label }} — {{ o.amount }}</option>
+                        </select>
+                        <button mat-raised-button color="primary"
+                                [disabled]="addingTier || (t.billingEnabled && !selectedTierPrice[t.groupId])"
+                                (click)="addTier(t.groupId, selectedTierPrice[t.groupId])">
+                            <mat-icon>add</mat-icon>
+                            Add
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="section billing-section" *ngIf="accountInfo?.billingRequired || accountInfo?.hasBilling">
             <h3>Billing</h3>
             <p class="section-description">
@@ -613,6 +661,7 @@
                 [email]="userEmail"
                 [isChangingPlan]="showChangeSubscription"
                 [currentPriceId]="currentPriceId"
+                [checkoutItems]="checkoutItems"
                 (checkoutSuccess)="onCheckoutSuccess($event)"
                 (checkoutError)="onCheckoutError($event)"
                 (checkoutCancel)="onCheckoutCancel()">

--- a/client/src/app/components/rdio-scanner/settings/settings.component.scss
+++ b/client/src/app/components/rdio-scanner/settings/settings.component.scss
@@ -1333,3 +1333,41 @@
   }
 }
 
+
+/* Multi-tier membership management */
+.tiers-section {
+    .tier-list { margin-bottom: 12px; }
+    .tier-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px 0;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    }
+    .tier-main { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .tier-name { font-weight: 600; }
+    .tier-desc { color: #888; font-size: 12px; }
+    .tier-badge {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.4px;
+        padding: 1px 6px;
+        border-radius: 4px;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        color: #666;
+    }
+    .tier-badge--primary { border-color: #3f51b5; color: #3f51b5; }
+    .tier-badge--paid { border-color: #2e7d32; color: #2e7d32; }
+    .tier-badge--warn { border-color: #cc7000; color: #cc7000; }
+    .add-tier {
+        margin-top: 12px;
+        h4 { margin: 0 0 6px; font-size: 13px; }
+    }
+    .add-tier-controls {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        select { padding: 4px 6px; border-radius: 4px; }
+    }
+}

--- a/client/src/app/components/rdio-scanner/settings/settings.component.ts
+++ b/client/src/app/components/rdio-scanner/settings/settings.component.ts
@@ -877,25 +877,91 @@ export class RdioScannerSettingsComponent implements OnDestroy, OnInit {
         this.showChangeSubscription = true;
         this.showCheckout = true; // Reuse the same checkout modal
     }
+
+    /** Combined-checkout items when adding a tier requires a fresh subscription. */
+    checkoutItems: { groupId: number; priceId: string }[] | null = null;
+    addingTier = false;
+    /** Price selection per available tier in the add picker (groupId -> priceId). */
+    selectedTierPrice: { [groupId: number]: string } = {};
+
+    /** Add a public tier. Paid tiers with an active subscription are added
+     *  server-side with proration; otherwise a combined checkout is shown. */
+    addTier(groupId: number, priceId?: string): void {
+        const pin = this.getPin();
+        if (!pin) {
+            this.snackBar.open('Please log in to manage your subscription', 'Close', { duration: 3000 });
+            return;
+        }
+        this.addingTier = true;
+        const headers = this.getAuthHeaders();
+        this.http.post<any>('/api/subscription/groups/add', { groupId, priceId: priceId || '' }, {
+            headers,
+            params: { pin: encodeURIComponent(pin) },
+        }).subscribe({
+            next: (res) => {
+                this.addingTier = false;
+                if (res.added) {
+                    this.snackBar.open('Tier added to your subscription', 'Close', { duration: 3000 });
+                    this.loadAccountInfo();
+                } else if (res.needsCheckout && priceId) {
+                    // No active subscription yet — complete a combined checkout.
+                    this.userEmail = this.accountInfo?.email || res.email || '';
+                    this.checkoutItems = [{ groupId, priceId }];
+                    this.showChangeSubscription = false;
+                    this.showCheckout = true;
+                }
+            },
+            error: (error) => {
+                this.addingTier = false;
+                this.snackBar.open(error.error?.error || 'Failed to add tier', 'Close', { duration: 5000 });
+            },
+        });
+    }
+
+    /** Remove a tier from the user's subscription (or membership for a free tier). */
+    removeTier(groupId: number): void {
+        if (!confirm('Remove this tier? You will lose access to its channels.')) {
+            return;
+        }
+        const pin = this.getPin();
+        if (!pin) {
+            return;
+        }
+        const headers = this.getAuthHeaders();
+        this.http.post<any>('/api/subscription/groups/remove', { groupId }, {
+            headers,
+            params: { pin: encodeURIComponent(pin) },
+        }).subscribe({
+            next: () => {
+                this.snackBar.open('Tier removed', 'Close', { duration: 3000 });
+                this.loadAccountInfo();
+            },
+            error: (error) => {
+                this.snackBar.open(error.error?.error || 'Failed to remove tier', 'Close', { duration: 5000 });
+            },
+        });
+    }
     
     onCheckoutSuccess(event: any): void {
         console.log('Checkout successful:', event);
         this.showCheckout = false;
         this.showChangeSubscription = false;
+        this.checkoutItems = null;
         // Reload account info to get updated subscription status
         this.loadAccountInfo();
         // Reload page to get updated subscription status
         window.location.reload();
     }
-    
+
     onCheckoutError(event: any): void {
         console.error('Checkout error:', event);
         // Keep checkout open on error
     }
-    
+
     onCheckoutCancel(): void {
         this.showCheckout = false;
         this.showChangeSubscription = false;
+        this.checkoutItems = null;
     }
     
     getSubscriptionStatusDisplay(): string {

--- a/client/src/app/components/rdio-scanner/stripe-checkout/stripe-checkout.component.ts
+++ b/client/src/app/components/rdio-scanner/stripe-checkout/stripe-checkout.component.ts
@@ -36,6 +36,9 @@ export class RdioScannerStripeCheckoutComponent implements OnInit, OnDestroy {
   @Input() customCancelUrl: string | null = null;
   @Input() isChangingPlan: boolean = false;
   @Input() currentPriceId: string | null = null;
+  /** When set, a combined multi-tier checkout is posted (one item per paid group)
+   *  and the single-price selection UI is bypassed. */
+  @Input() checkoutItems: { groupId: number; priceId: string }[] | null = null;
   @Output() checkoutSuccess = new EventEmitter<any>();
   @Output() checkoutError = new EventEmitter<any>();
   @Output() checkoutCancel = new EventEmitter<void>();
@@ -83,9 +86,10 @@ export class RdioScannerStripeCheckoutComponent implements OnInit, OnDestroy {
   }
 
   async handleSubmit(): Promise<void> {
+    const combined = this.checkoutItems && this.checkoutItems.length > 0;
     const priceId = this.selectedPriceId;
-    
-    if (!priceId) {
+
+    if (!combined && !priceId) {
       this.error = 'Please select a pricing option.';
       return;
     }
@@ -108,18 +112,20 @@ export class RdioScannerStripeCheckoutComponent implements OnInit, OnDestroy {
       const cancelUrl = this.customCancelUrl && this.customCancelUrl.length > 0
         ? this.customCancelUrl
         : `${baseUrl}/?checkout=cancel`;
-      
+
+      const body: any = { email: this.email, successUrl, cancelUrl };
+      if (combined) {
+        body.items = this.checkoutItems;
+      } else {
+        body.priceId = priceId;
+      }
+
       const response = await fetch('/api/stripe/create-checkout-session', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          priceId: priceId,
-          email: this.email,
-          successUrl: successUrl,
-          cancelUrl: cancelUrl
-        })
+        body: JSON.stringify(body)
       });
 
       const result = await response.json();

--- a/client/src/app/components/rdio-scanner/user-registration/user-registration.component.html
+++ b/client/src/app/components/rdio-scanner/user-registration/user-registration.component.html
@@ -23,8 +23,39 @@
         <p *ngIf="publicGroupInfo?.description">{{ publicGroupInfo.description }}</p>
       </div>
       
-      <!-- Pricing Information -->
-      <div class="pricing-section" *ngIf="publicGroupInfo?.billingEnabled && publicGroupInfo?.pricingOptions && publicGroupInfo.pricingOptions.length > 0">
+      <!-- Tier selection (multiple public tiers) -->
+      <div class="tiers-section" *ngIf="tiers.length > 0">
+        <h4>Choose your tiers</h4>
+        <p class="tiers-hint">Select one or more tiers to join. Paid tiers are billed together on a single subscription.</p>
+        <div class="tier-option" *ngFor="let t of tiers">
+          <label class="tier-check">
+            <input type="checkbox" [checked]="selectedTiers[t.groupId]" (change)="toggleTier(t.groupId)">
+            <span class="tier-title">{{ t.name }}</span>
+            <span class="tier-meta" *ngIf="t.talkgroupCount"> — {{ t.talkgroupCount }} channels</span>
+            <span class="tier-free" *ngIf="!t.billingEnabled"> · Free</span>
+          </label>
+          <p class="tier-desc" *ngIf="t.description">{{ t.description }}</p>
+          <div class="tier-prices" *ngIf="selectedTiers[t.groupId] && t.billingEnabled && t.pricingOptions?.length">
+            <label class="tier-price-option" *ngFor="let o of t.pricingOptions">
+              <input type="radio" name="price-{{ t.groupId }}" [value]="o.priceId"
+                     [checked]="tierPrice[t.groupId] === o.priceId"
+                     (change)="tierPrice[t.groupId] = o.priceId">
+              <span>{{ o.label }} — {{ o.amount }}</span>
+            </label>
+          </div>
+          <div class="tier-primary" *ngIf="selectedTiers[t.groupId] && selectedTierIds().length > 1">
+            <label>
+              <input type="radio" name="primaryTier" [value]="t.groupId"
+                     [checked]="primaryTierId === t.groupId"
+                     (change)="primaryTierId = t.groupId">
+              Set as primary (home) tier
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <!-- Legacy single-group pricing (only when the server returns no tiers) -->
+      <div class="pricing-section" *ngIf="tiers.length === 0 && publicGroupInfo?.billingEnabled && publicGroupInfo?.pricingOptions && publicGroupInfo.pricingOptions.length > 0">
         <h4>Pricing Plans</h4>
         <div class="pricing-options">
           <div class="pricing-option" *ngFor="let option of publicGroupInfo.pricingOptions">

--- a/client/src/app/components/rdio-scanner/user-registration/user-registration.component.scss
+++ b/client/src/app/components/rdio-scanner/user-registration/user-registration.component.scss
@@ -306,3 +306,33 @@
     }
   }
 }
+
+/* Multi-tier signup picker */
+.tiers-section {
+    margin: 12px 0;
+    .tiers-hint { color: #888; font-size: 12px; margin: 0 0 8px; }
+    .tier-option {
+        border: 1px solid rgba(0, 0, 0, 0.12);
+        border-radius: 6px;
+        padding: 10px 12px;
+        margin-bottom: 8px;
+    }
+    .tier-check {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+        font-weight: 600;
+    }
+    .tier-meta { color: #888; font-weight: 400; }
+    .tier-free { color: #2e7d32; font-weight: 400; }
+    .tier-desc { color: #777; font-size: 12px; margin: 6px 0 0; }
+    .tier-prices {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin: 8px 0 0 24px;
+    }
+    .tier-price-option { display: flex; align-items: center; gap: 6px; cursor: pointer; }
+    .tier-primary { margin: 6px 0 0 24px; font-size: 12px; color: #555; }
+}

--- a/client/src/app/components/rdio-scanner/user-registration/user-registration.component.ts
+++ b/client/src/app/components/rdio-scanner/user-registration/user-registration.component.ts
@@ -42,6 +42,12 @@ export class RdioScannerUserRegistrationComponent implements OnInit {
   availableChannels: any[] = [];
   loadingChannels = false;
   showChannels = false;
+
+  // Multi-tier public registration
+  tiers: any[] = [];
+  selectedTiers: { [groupId: number]: boolean } = {};
+  tierPrice: { [groupId: number]: string } = {};
+  primaryTierId: number | null = null;
   
   // Invite only mode
   isInviteOnlyMode = true; // Default to true until we load settings
@@ -249,12 +255,46 @@ export class RdioScannerUserRegistrationComponent implements OnInit {
     this.http.get<any>('/api/public-registration-info').subscribe({
       next: (info) => {
         this.publicGroupInfo = info;
+        this.tiers = info.tiers || [];
+        // Auto-select a lone tier so single-tier signup is unchanged.
+        if (this.tiers.length === 1) {
+          this.selectedTiers[this.tiers[0].groupId] = true;
+          this.primaryTierId = this.tiers[0].groupId;
+        }
         this.loadingGroupInfo = false;
       },
       error: (error) => {
         console.error('Error loading public registration info:', error);
         this.loadingGroupInfo = false;
       }
+    });
+  }
+
+  toggleTier(groupId: number): void {
+    this.selectedTiers[groupId] = !this.selectedTiers[groupId];
+    if (this.selectedTiers[groupId]) {
+      if (this.primaryTierId === null) {
+        this.primaryTierId = groupId;
+      }
+    } else if (this.primaryTierId === groupId) {
+      const remaining = this.selectedTierIds();
+      this.primaryTierId = remaining.length ? remaining[0] : null;
+    }
+  }
+
+  selectedTierIds(): number[] {
+    return this.tiers.filter(t => this.selectedTiers[t.groupId]).map(t => t.groupId);
+  }
+
+  /** True when every selected paid tier has a chosen price. */
+  tierSelectionValid(): boolean {
+    const ids = this.selectedTierIds();
+    if (ids.length === 0) {
+      return false;
+    }
+    return this.tiers.every(t => {
+      if (!this.selectedTiers[t.groupId]) { return true; }
+      return !t.billingEnabled || !!this.tierPrice[t.groupId];
     });
   }
 
@@ -424,28 +464,46 @@ export class RdioScannerUserRegistrationComponent implements OnInit {
   }
 
   onSubmit(): void {
+    const usingTiers = !this.registrationForm.value.accessCode?.trim() && this.tiers.length > 0;
+    if (usingTiers && !this.tierSelectionValid()) {
+      this.error = 'Select at least one tier and choose a plan for each paid tier.';
+      return;
+    }
     if (this.registrationForm.valid && !this.loading) {
       this.loading = true;
       this.error = '';
 
+      const email = this.registrationForm.value.email.toLowerCase();
       const formData = {
-        email: this.registrationForm.value.email.toLowerCase(), // Ensure email is lowercase
+        email, // Ensure email is lowercase
         password: this.registrationForm.value.password,
         firstName: this.registrationForm.value.firstName,
         lastName: this.registrationForm.value.lastName,
         zipCode: this.registrationForm.value.zipCode
       } as any;
-      
+
       // Include verification code if email verification is required
       if (this.emailVerificationRequired && this.verificationCode) {
         formData.verificationCode = this.verificationCode;
       }
-      
+
       // Include accessCode if provided (unified field for invitation and registration codes)
       if (this.registrationForm.value.accessCode && this.registrationForm.value.accessCode.trim() !== '') {
         formData.accessCode = this.registrationForm.value.accessCode;
       }
-      
+
+      // Multi-tier public signup: chosen tiers + primary.
+      const chosenIds = usingTiers ? this.selectedTierIds() : [];
+      if (chosenIds.length > 0) {
+        formData.groupIds = chosenIds;
+        formData.primaryGroupId = this.primaryTierId || chosenIds[0];
+      }
+
+      // Paid tiers → drive a combined checkout after registration.
+      const paidItems = this.tiers
+        .filter(t => this.selectedTiers[t.groupId] && t.billingEnabled && this.tierPrice[t.groupId])
+        .map(t => ({ groupId: t.groupId, priceId: this.tierPrice[t.groupId] }));
+
       this.http.post('/api/user/register', formData).subscribe({
         next: async (response: any) => {
           this.loading = false;
@@ -456,11 +514,37 @@ export class RdioScannerUserRegistrationComponent implements OnInit {
           } else {
             this.generatedPin = null;
           }
+
+          // If paid tiers were chosen, start a combined Stripe checkout now.
+          if (paidItems.length > 0) {
+            try {
+              const baseUrl = window.location.origin;
+              const res = await fetch('/api/stripe/create-checkout-session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  email,
+                  items: paidItems,
+                  successUrl: `${baseUrl}/?checkout=success`,
+                  cancelUrl: `${baseUrl}/?checkout=cancel`,
+                }),
+              });
+              const result = await res.json();
+              if (result.checkoutUrl) {
+                window.location.href = result.checkoutUrl;
+                return;
+              }
+              this.error = result.error || 'Could not start checkout.';
+            } catch (e: any) {
+              this.error = e?.message || 'Could not start checkout.';
+            }
+            return;
+          }
+
           const alreadyVerified =
             response?.verified === true || response?.message === 'User registered successfully.';
           if (alreadyVerified) {
             this.success = false;
-            const email = (this.registrationForm.value.email || '').toLowerCase();
             await this.router.navigate(['/setup/plan'], { queryParams: { email } });
             return;
           }

--- a/server/admin.go
+++ b/server/admin.go
@@ -6449,9 +6449,10 @@ func (admin *Admin) UserUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		ConnectionLimit      *uint   `json:"connectionLimit"`
 		SystemDelays         *string `json:"systemDelays"`
 		TalkgroupDelays      *string `json:"talkgroupDelays"`
-		RegeneratePin        bool    `json:"regeneratePin"`
-		UserGroupId          *uint64 `json:"userGroupId"`
-		IsGroupAdmin         *bool   `json:"isGroupAdmin"`
+		RegeneratePin        bool     `json:"regeneratePin"`
+		UserGroupId          *uint64  `json:"userGroupId"`
+		UserGroupIds         *[]uint64 `json:"userGroupIds"`
+		IsGroupAdmin         *bool    `json:"isGroupAdmin"`
 		SystemAdmin             *bool   `json:"systemAdmin"`
 		PushSystemNoAudioAlerts   *bool   `json:"pushSystemNoAudioAlerts"`
 		PushApiKeyNoAudioAlerts   *bool   `json:"pushApiKeyNoAudioAlerts"`
@@ -6536,6 +6537,24 @@ func (admin *Admin) UserUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		if user.IsGroupAdmin && oldGroupId != *request.UserGroupId {
 			user.IsGroupAdmin = false
 		}
+	}
+
+	// Multi-group membership (union access). Applied after the primary so it is
+	// folded into the set; SetGroupIds keeps the primary if present.
+	if request.UserGroupIds != nil {
+		ids := append([]uint64{}, *request.UserGroupIds...)
+		for _, gid := range ids {
+			if gid != 0 && admin.Controller.UserGroups.Get(gid) == nil {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "Invalid group in memberships"})
+				return
+			}
+		}
+		if effectiveUserGroupId != 0 {
+			ids = append(ids, effectiveUserGroupId)
+		}
+		user.SetGroupIds(ids)
+		effectiveUserGroupId = user.UserGroupId
 	}
 
 	if request.IsGroupAdmin != nil {

--- a/server/api.go
+++ b/server/api.go
@@ -41,6 +41,7 @@ import (
 	checkoutsession "github.com/stripe/stripe-go/v76/checkout/session"
 	"github.com/stripe/stripe-go/v76/customer"
 	"github.com/stripe/stripe-go/v76/subscription"
+	subscriptionitem "github.com/stripe/stripe-go/v76/subscriptionitem"
 	"github.com/stripe/stripe-go/v76/webhook"
 )
 
@@ -585,6 +586,9 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		AccessCode       string `json:"accessCode"`       // Unified field for both invitation and registration codes
 		TurnstileToken   string `json:"turnstile_token"`
 		VerificationCode string `json:"verificationCode"` // Email verification code (if emailVerificationRequired)
+		// Multi-tier public signup: the public groups the user chose to join.
+		GroupIds       []uint64 `json:"groupIds"`
+		PrimaryGroupId uint64   `json:"primaryGroupId"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
@@ -684,6 +688,10 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	var targetGroup *UserGroup
 	var regCode *RegistrationCode
 	var invitationId int64
+	// Multi-tier public signup: the full set of chosen public groups (empty for
+	// single-group invitation / code flows).
+	var chosenGroupIds []uint64
+	isMultiGroupSignup := false
 
 	// Check if invitation code is provided (takes precedence over registration code)
 	if request.InvitationCode != "" {
@@ -747,6 +755,37 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		invitationId = invitation.Id
+	} else if api.Controller.Options.PublicRegistrationEnabled && len(request.GroupIds) > 0 {
+		// Multi-tier public signup: user chose a set of public groups. Each must
+		// be public and self-billable ("all_users" billing or free).
+		seen := map[uint64]bool{}
+		for _, gid := range request.GroupIds {
+			if gid == 0 || seen[gid] {
+				continue
+			}
+			g := api.Controller.UserGroups.Get(gid)
+			if g == nil || !g.IsPublicRegistration {
+				api.exitWithError(w, http.StatusBadRequest, "One or more selected tiers are not available for public registration")
+				return
+			}
+			if !g.IsSelfBillable() {
+				api.exitWithError(w, http.StatusBadRequest, fmt.Sprintf("Tier %q cannot be self-selected", g.Name))
+				return
+			}
+			seen[gid] = true
+			chosenGroupIds = append(chosenGroupIds, gid)
+		}
+		if len(chosenGroupIds) == 0 {
+			api.exitWithError(w, http.StatusBadRequest, "Select at least one tier")
+			return
+		}
+		// Primary = requested primary if chosen, else the first chosen tier.
+		primaryId := chosenGroupIds[0]
+		if request.PrimaryGroupId != 0 && seen[request.PrimaryGroupId] {
+			primaryId = request.PrimaryGroupId
+		}
+		targetGroup = api.Controller.UserGroups.Get(primaryId)
+		isMultiGroupSignup = true
 	} else if api.Controller.Options.PublicRegistrationEnabled {
 		// Check if public registration is enabled and has a public group
 		publicGroup := api.Controller.UserGroups.GetPublicRegistrationGroup()
@@ -815,14 +854,31 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Check max users limit for the group
-	// This check is enforced regardless of registration code maxUses setting
-	// Even if a code has unlimited uses (maxUses = 0), the group's maxUsers limit still applies
-	if targetGroup.MaxUsers > 0 {
-		currentUserCount := api.Controller.UserGroups.GetUserCount(targetGroup.Id, api.Controller.Users)
-		if currentUserCount >= targetGroup.MaxUsers {
-			api.exitWithError(w, http.StatusForbidden, fmt.Sprintf("Group has reached maximum user limit of %d", targetGroup.MaxUsers))
+	// The membership set: all chosen tiers for a multi-tier signup, else the
+	// single target group.
+	if !isMultiGroupSignup {
+		chosenGroupIds = []uint64{targetGroup.Id}
+	}
+
+	// Check max users limit for each chosen group.
+	// This check is enforced regardless of registration code maxUses setting.
+	for _, gid := range chosenGroupIds {
+		g := api.Controller.UserGroups.Get(gid)
+		if g == nil || g.MaxUsers == 0 {
+			continue
+		}
+		if api.Controller.UserGroups.GetUserCount(gid, api.Controller.Users) >= g.MaxUsers {
+			api.exitWithError(w, http.StatusForbidden, fmt.Sprintf("Tier %q has reached its maximum user limit of %d", g.Name, g.MaxUsers))
 			return
+		}
+	}
+
+	// Any paid, self-billable tier among the chosen set requires completing checkout.
+	anyPaidSelfBillable := false
+	for _, gid := range chosenGroupIds {
+		if g := api.Controller.UserGroups.Get(gid); g != nil && g.BillingEnabled && g.IsSelfBillable() {
+			anyPaidSelfBillable = true
+			break
 		}
 	}
 
@@ -836,6 +892,9 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		ConnectionLimit: targetGroup.ConnectionLimit, // Inherit group's connection limit
 		CreatedAt:       fmt.Sprintf("%d", time.Now().Unix()),
 	}
+	// Record full membership (primary is folded in). Single-group flows would be
+	// canonicalized to [primary] anyway, but set it explicitly for clarity.
+	user.SetGroupIds(chosenGroupIds)
 
 	if err := user.HashPassword(request.Password); err != nil {
 		api.exitWithError(w, http.StatusInternalServerError, "Failed to hash password")
@@ -847,8 +906,9 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create Stripe customer if Stripe is enabled AND group billing is enabled
-	if api.Controller.Options.StripePaywallEnabled && api.Controller.Options.StripeSecretKey != "" && targetGroup.BillingEnabled {
+	// Create Stripe customer if Stripe is enabled AND billing applies (the primary
+	// group is billing-enabled, or any chosen tier in a multi-tier signup is paid).
+	if api.Controller.Options.StripePaywallEnabled && api.Controller.Options.StripeSecretKey != "" && (targetGroup.BillingEnabled || anyPaidSelfBillable) {
 		stripe.Key = api.Controller.Options.StripeSecretKey
 
 		// Check if group uses shared customer ID for admins
@@ -889,8 +949,21 @@ func (api *Api) UserRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	// Sync config to file if enabled
 	api.Controller.SyncConfigToFile()
 
-	// Handle billing setup for new users in billing-enabled groups
-	if targetGroup.BillingEnabled {
+	// Multi-tier signup: if any chosen tier is paid, the user must complete the
+	// combined checkout before gaining access; all-free selections stay active.
+	if isMultiGroupSignup {
+		if anyPaidSelfBillable {
+			user.SubscriptionStatus = "incomplete"
+			user.PinExpiresAt = uint64(time.Now().Unix() - 86400) // expired until checkout completes
+			api.Controller.Users.Update(user)
+			api.Controller.Users.Write(api.Controller.Database)
+			api.Controller.SyncConfigToFile()
+			log.Printf("Multi-tier signup %s: expired PIN pending combined checkout", user.Email)
+		}
+	}
+
+	// Handle billing setup for new users in billing-enabled groups (single-group flows)
+	if !isMultiGroupSignup && targetGroup.BillingEnabled {
 		if targetGroup.BillingMode == "group_admin" && !user.IsGroupAdmin {
 			// For non-admin users in admin-managed billing groups, sync subscription status from admin
 			syncedFromAdmin := false
@@ -2091,6 +2164,28 @@ func (api *Api) handleSubscriptionEvent(rawData []byte, status string) {
 		}
 	}
 
+	// Reconcile paid ("all_users" billing) memberships with the subscription so
+	// Billing-Portal add/remove syncs back into userGroupIds. On cancellation,
+	// drop those paid memberships (free/group_admin memberships are preserved).
+	if status == "canceled" || status == "incomplete_expired" {
+		for _, gid := range user.GroupIds() {
+			if g := api.Controller.UserGroups.Get(gid); g != nil && g.BillingEnabled && g.BillingMode == "all_users" {
+				user.RemoveGroup(gid)
+			}
+		}
+	} else {
+		recSub := sub
+		if recSub.Items == nil || len(recSub.Items.Data) == 0 {
+			stripe.Key = api.Controller.Options.StripeSecretKey
+			if stripe.Key != "" {
+				if fetched, err := subscription.Get(subData.ID, nil); err == nil {
+					recSub = fetched
+				}
+			}
+		}
+		api.reconcilePaidMembershipsFromSubscription(user, recSub)
+	}
+
 	// Save changes to database
 	api.Controller.Users.Update(user)
 	if err := api.Controller.Users.Write(api.Controller.Database); err != nil {
@@ -2456,6 +2551,60 @@ func (api *Api) resolveUserFromCheckoutSession(session *stripe.CheckoutSession) 
 }
 
 // Handle checkout session completed
+// groupForPriceId returns the billing-enabled group whose pricing options
+// include the given Stripe price. Price IDs are required to be unique per group.
+func (api *Api) groupForPriceId(priceId string) *UserGroup {
+	if priceId == "" {
+		return nil
+	}
+	for _, g := range api.Controller.UserGroups.GetAll() {
+		if g == nil || !g.BillingEnabled {
+			continue
+		}
+		for _, opt := range g.GetPricingOptions() {
+			if opt.PriceId == priceId {
+				return g
+			}
+		}
+	}
+	return nil
+}
+
+// reconcilePaidMembershipsFromSubscription rewrites the user's paid
+// ("all_users" billing) memberships to exactly match the line items on their
+// combined subscription, preserving free and group_admin memberships. Call
+// after any subscription change (checkout, add/remove, webhook).
+func (api *Api) reconcilePaidMembershipsFromSubscription(user *User, sub *stripe.Subscription) {
+	if user == nil || sub == nil {
+		return
+	}
+	paid := map[uint64]bool{}
+	if sub.Items != nil {
+		for _, item := range sub.Items.Data {
+			if item == nil || item.Price == nil {
+				continue
+			}
+			if g := api.groupForPriceId(item.Price.ID); g != nil && g.BillingMode == "all_users" {
+				paid[g.Id] = true
+			}
+		}
+	}
+	// Keep every membership that is NOT an all_users-billing group (free +
+	// group_admin), then re-add exactly the groups still on the subscription.
+	next := []uint64{}
+	for _, gid := range user.GroupIds() {
+		g := api.Controller.UserGroups.Get(gid)
+		if g != nil && g.BillingEnabled && g.BillingMode == "all_users" {
+			continue
+		}
+		next = append(next, gid)
+	}
+	for gid := range paid {
+		next = append(next, gid)
+	}
+	user.SetGroupIds(next)
+}
+
 func (api *Api) handleCheckoutSessionCompleted(event stripe.Event) {
 	var session stripe.CheckoutSession
 	err := json.Unmarshal(event.Data.Raw, &session)
@@ -2596,19 +2745,23 @@ func (api *Api) handleCheckoutSessionCompleted(event stripe.Event) {
 		return
 	}
 
-	// If user already has a subscription, cancel it before setting the new one
+	// If the user has a different prior subscription, cancel it ONLY when it is
+	// not still active/trialing — a valid combined subscription must not be nuked
+	// on a return checkout. (Adding tiers to an active sub goes through the
+	// self-service add endpoint, not a fresh checkout.)
+	// Reaching a fresh Checkout means a replace (first-time subscribe, lapsed
+	// re-subscribe, or Change Plan) — self-service tier ADDs never come through
+	// Checkout for a user with an active subscription (they use the add endpoint
+	// / subscription items). So always cancel any different prior subscription to
+	// avoid orphaning it and double-billing.
 	oldSubscriptionId := user.StripeSubscriptionId
 	if oldSubscriptionId != "" && oldSubscriptionId != subscriptionID {
-		log.Printf("User has existing subscription %s, canceling it before setting new subscription %s", oldSubscriptionId, subscriptionID)
 		stripe.Key = api.Controller.Options.StripeSecretKey
 		if stripe.Key != "" {
-			// Cancel the old subscription immediately (they're switching plans)
-			_, err := subscription.Cancel(oldSubscriptionId, nil)
-			if err != nil {
+			if _, err := subscription.Cancel(oldSubscriptionId, nil); err != nil {
 				log.Printf("Warning: Failed to cancel old subscription %s for user %s: %v", oldSubscriptionId, user.Email, err)
-				// Continue anyway - we'll still set the new subscription
 			} else {
-				log.Printf("Successfully canceled old subscription %s for user %s", oldSubscriptionId, user.Email)
+				log.Printf("Canceled prior subscription %s for user %s before activating new %s", oldSubscriptionId, user.Email, subscriptionID)
 			}
 		}
 	}
@@ -2630,6 +2783,8 @@ func (api *Api) handleCheckoutSessionCompleted(event stripe.Event) {
 		} else {
 			log.Printf("DEBUG: ⚠ Warning: Subscription %s has no CurrentPeriodEnd set", subscriptionID)
 		}
+		// Sync paid memberships from the (possibly multi-item) subscription.
+		api.reconcilePaidMembershipsFromSubscription(user, sub)
 	} else {
 		log.Printf("DEBUG: ⚠ No subscription object available for PIN expiration calculation")
 	}
@@ -2671,7 +2826,11 @@ func (api *Api) CreateCheckoutSessionHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	var request struct {
-		PriceId    string `json:"priceId"`
+		PriceId string `json:"priceId"` // legacy single-tier form
+		Items   []struct {
+			GroupId uint64 `json:"groupId"`
+			PriceId string `json:"priceId"`
+		} `json:"items"` // multi-tier form: one entry per paid group
 		Email      string `json:"email"`
 		SuccessUrl string `json:"successUrl"`
 		CancelUrl  string `json:"cancelUrl"`
@@ -2698,91 +2857,127 @@ func (api *Api) CreateCheckoutSessionHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Get group and determine which price ID to use: group price ID is required
-	group := api.Controller.UserGroups.Get(user.UserGroupId)
-	if group == nil || !group.BillingEnabled {
-		api.exitWithError(w, http.StatusBadRequest, "User is not in a billing-enabled group")
+	// Normalize the legacy single priceId into one item on the user's primary group.
+	type checkoutReqItem struct {
+		groupId uint64
+		priceId string
+	}
+	reqItems := []checkoutReqItem{}
+	for _, it := range request.Items {
+		reqItems = append(reqItems, checkoutReqItem{groupId: it.GroupId, priceId: it.PriceId})
+	}
+	if len(reqItems) == 0 && request.PriceId != "" {
+		reqItems = append(reqItems, checkoutReqItem{groupId: user.UserGroupId, priceId: request.PriceId})
+	}
+	if len(reqItems) == 0 {
+		api.exitWithError(w, http.StatusBadRequest, "Nothing to checkout")
 		return
 	}
 
-	priceId := request.PriceId
-	if priceId == "" {
-		api.exitWithError(w, http.StatusBadRequest, "Price ID is required")
-		return
+	// Validate every item: group must be a self-billable, billing-enabled group
+	// whose pricing options include the price. Reject duplicate prices (they map
+	// ambiguously back to groups). Determine tax (automatic wins) and trial (max).
+	lineItems := []*stripe.CheckoutSessionLineItemParams{}
+	anyAutomaticTax := false
+	maxTrialDays := 0
+	seenPrice := map[string]bool{}
+	groupIds := []string{}
+	type resolvedLine struct {
+		group   *UserGroup
+		priceId string
+		taxMode string
 	}
-
-	// Validate that the requested price ID is one of the valid pricing options for this group
-	pricingOptions := group.GetPricingOptions()
-	validPriceId := false
-	for _, option := range pricingOptions {
-		if option.PriceId == priceId {
-			validPriceId = true
-			break
+	resolved := []resolvedLine{}
+	for _, it := range reqItems {
+		group := api.Controller.UserGroups.Get(it.groupId)
+		if group == nil || !group.BillingEnabled || !group.IsSelfBillable() {
+			api.exitWithError(w, http.StatusBadRequest, "Invalid or non-self-billable tier in checkout")
+			return
 		}
-	}
-
-	if !validPriceId {
-		api.exitWithError(w, http.StatusBadRequest, "Invalid price ID for this group")
-		return
-	}
-
-	log.Printf("Using price ID %s for user %s (group: %s)", priceId, request.Email, group.Name)
-
-	// Determine tax mode — fall back to legacy collectSalesTax if taxMode not yet set
-	taxMode := group.TaxMode
-	if taxMode == "" {
-		if group.CollectSalesTax {
-			taxMode = "automatic"
-		} else {
-			taxMode = "none"
+		trialDays := -1
+		for _, o := range group.GetPricingOptions() {
+			if o.PriceId == it.priceId {
+				trialDays = o.TrialDays
+				break
+			}
 		}
+		if trialDays < 0 {
+			api.exitWithError(w, http.StatusBadRequest, fmt.Sprintf("Invalid price ID for tier %q", group.Name))
+			return
+		}
+		if seenPrice[it.priceId] {
+			api.exitWithError(w, http.StatusBadRequest, "Duplicate price in checkout")
+			return
+		}
+		seenPrice[it.priceId] = true
+
+		taxMode := group.TaxMode
+		if taxMode == "" {
+			if group.CollectSalesTax {
+				taxMode = "automatic"
+			} else {
+				taxMode = "none"
+			}
+		}
+		if taxMode == "automatic" {
+			anyAutomaticTax = true
+		}
+		if trialDays > maxTrialDays {
+			maxTrialDays = trialDays
+		}
+		resolved = append(resolved, resolvedLine{group: group, priceId: it.priceId, taxMode: taxMode})
+		groupIds = append(groupIds, fmt.Sprintf("%d", group.Id))
 	}
 
-	// Build line item — tax rates are attached here for fixed mode
-	lineItem := &stripe.CheckoutSessionLineItemParams{
-		Price:    stripe.String(priceId),
-		Quantity: stripe.Int64(1),
+	for _, rl := range resolved {
+		li := &stripe.CheckoutSessionLineItemParams{
+			Price:    stripe.String(rl.priceId),
+			Quantity: stripe.Int64(1),
+		}
+		// Automatic tax wins: when any tier is automatic, do not attach per-line
+		// fixed rates (Stripe cannot mix automatic and manual tax on one sub).
+		if !anyAutomaticTax && rl.taxMode == "fixed" && rl.group.StripeTaxRateId != "" {
+			li.TaxRates = stripe.StringSlice([]string{rl.group.StripeTaxRateId})
+		}
+		lineItems = append(lineItems, li)
 	}
-	if taxMode == "fixed" && group.StripeTaxRateId != "" {
-		lineItem.TaxRates = stripe.StringSlice([]string{group.StripeTaxRateId})
-	}
+
+	log.Printf("Creating combined checkout for user %s: %d line item(s), groups=[%s]", request.Email, len(lineItems), strings.Join(groupIds, ","))
 
 	// Create Stripe Checkout Session
 	params := &stripe.CheckoutSessionParams{
 		PaymentMethodTypes: stripe.StringSlice([]string{
 			"card",
 		}),
-		LineItems:  []*stripe.CheckoutSessionLineItemParams{lineItem},
+		LineItems:  lineItems,
 		Mode:       stripe.String(string(stripe.CheckoutSessionModeSubscription)),
 		SuccessURL: stripe.String(request.SuccessUrl),
 		CancelURL:  stripe.String(request.CancelUrl),
 		Locale:     stripe.String("en"),
 		AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{
-			Enabled: stripe.Bool(taxMode == "automatic"),
+			Enabled: stripe.Bool(anyAutomaticTax),
 		},
 	}
 	params.ClientReferenceID = stripe.String(fmt.Sprintf("%d", user.Id))
 	params.Metadata = map[string]string{
 		"rdio_user_id":    fmt.Sprintf("%d", user.Id),
 		"rdio_user_email": user.Email,
+		"rdio_group_ids":  strings.Join(groupIds, ","),
 	}
 
 	// Automatic tax requires a billing address from the customer
-	if taxMode == "automatic" {
+	if anyAutomaticTax {
 		params.CustomerUpdate = &stripe.CheckoutSessionCustomerUpdateParams{
 			Address: stripe.String("auto"),
 		}
 	}
 
-	// Add trial period if configured for this pricing option
-	for _, option := range pricingOptions {
-		if option.PriceId == priceId && option.TrialDays > 0 {
-			params.SubscriptionData = &stripe.CheckoutSessionSubscriptionDataParams{
-				TrialPeriodDays: stripe.Int64(int64(option.TrialDays)),
-			}
-			log.Printf("Adding %d day trial period for price %s", option.TrialDays, priceId)
-			break
+	// Trial is subscription-level: use the longest trial among selected tiers.
+	if maxTrialDays > 0 {
+		params.SubscriptionData = &stripe.CheckoutSessionSubscriptionDataParams{
+			TrialPeriodDays: stripe.Int64(int64(maxTrialDays)),
 		}
+		log.Printf("Adding %d day trial period (max across tiers)", maxTrialDays)
 	}
 
 	// Use existing Stripe customer ID if available, otherwise use email
@@ -4454,16 +4649,67 @@ func (api *Api) AccountGetHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Get current subscription price ID from Stripe if user has an active subscription
+	// Get subscription line items from Stripe: the first price (legacy
+	// currentPriceId) and the full set of billed price IDs (for per-group state).
+	subPriceIds := map[string]bool{}
 	if user.StripeSubscriptionId != "" && api.Controller.Options.StripeSecretKey != "" {
 		stripe.Key = api.Controller.Options.StripeSecretKey
 		sub, err := subscription.Get(user.StripeSubscriptionId, nil)
-		if err == nil && len(sub.Items.Data) > 0 {
-			// Get the price ID from the first subscription item
-			currentPriceId = sub.Items.Data[0].Price.ID
+		if err == nil && sub.Items != nil {
+			for i, item := range sub.Items.Data {
+				if item == nil || item.Price == nil {
+					continue
+				}
+				if i == 0 {
+					currentPriceId = item.Price.ID
+				}
+				subPriceIds[item.Price.ID] = true
+			}
 		} else if err != nil {
-			log.Printf("Failed to fetch subscription %s to get price ID: %v", user.StripeSubscriptionId, err)
+			log.Printf("Failed to fetch subscription %s to get price IDs: %v", user.StripeSubscriptionId, err)
 		}
+	}
+
+	// Per-group membership list (all tiers the user belongs to).
+	memberships := []map[string]interface{}{}
+	for _, gid := range user.GroupIds() {
+		g := api.Controller.UserGroups.Get(gid)
+		if g == nil {
+			continue
+		}
+		// Which of this group's prices is on the subscription (if any).
+		priceId := ""
+		for _, o := range g.GetPricingOptions() {
+			if subPriceIds[o.PriceId] {
+				priceId = o.PriceId
+				break
+			}
+		}
+		memberships = append(memberships, map[string]interface{}{
+			"groupId":        g.Id,
+			"name":           g.Name,
+			"billingEnabled": g.BillingEnabled,
+			"selfBillable":   g.IsSelfBillable(),
+			"paid":           priceId != "",
+			"priceId":        priceId,
+			"isPrimary":      g.Id == user.UserGroupId,
+			"pricingOptions": g.GetPricingOptions(),
+		})
+	}
+
+	// Public self-billable tiers the user has not joined yet (for the add picker).
+	availableTiers := []map[string]interface{}{}
+	for _, g := range api.Controller.UserGroups.GetPublicRegistrationGroups() {
+		if g == nil || user.IsMemberOf(g.Id) || !g.IsSelfBillable() {
+			continue
+		}
+		availableTiers = append(availableTiers, map[string]interface{}{
+			"groupId":        g.Id,
+			"name":           g.Name,
+			"description":    g.Description,
+			"billingEnabled": g.BillingEnabled,
+			"pricingOptions": g.GetPricingOptions(),
+		})
 	}
 
 	// Get pricing options from user's group if billing is enabled
@@ -4499,7 +4745,297 @@ func (api *Api) AccountGetHandler(w http.ResponseWriter, r *http.Request) {
 		"billingRequired":           billingRequired,
 		"pinExpired":                user.PinExpired(),
 		"pinExpiresAt":              user.PinExpiresAt,
+		"memberships":               memberships,
+		"availableTiers":            availableTiers,
 	})
+}
+
+// userFromRequestPin resolves the authenticated user from a ?pin= query param
+// or a Bearer token.
+func (api *Api) userFromRequestPin(r *http.Request) *User {
+	pin := r.URL.Query().Get("pin")
+	if pin == "" {
+		authHeader := r.Header.Get("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			pin = strings.TrimPrefix(authHeader, "Bearer ")
+		}
+	}
+	if pin == "" {
+		return nil
+	}
+	return api.Controller.Users.GetUserByPin(pin)
+}
+
+// SubscriptionGroupAddHandler adds a paid, self-billable public tier to the
+// user's combined subscription. With an active subscription the item is added
+// server-side with proration (charging the saved card); otherwise a combined
+// checkout URL is returned for the client to complete.
+func (api *Api) SubscriptionGroupAddHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		api.exitWithError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	user := api.userFromRequestPin(r)
+	if user == nil {
+		api.exitWithError(w, http.StatusUnauthorized, "PIN required")
+		return
+	}
+	var request struct {
+		GroupId uint64 `json:"groupId"`
+		PriceId string `json:"priceId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		api.exitWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	group := api.Controller.UserGroups.Get(request.GroupId)
+	if group == nil || !group.IsPublicRegistration || !group.IsSelfBillable() {
+		api.exitWithError(w, http.StatusBadRequest, "Tier is not available for self-service subscription")
+		return
+	}
+
+	// Free tier: membership-only, no Stripe.
+	if !group.BillingEnabled {
+		if user.IsMemberOf(request.GroupId) {
+			api.exitWithError(w, http.StatusBadRequest, "You already have this tier")
+			return
+		}
+		if group.MaxUsers > 0 && api.Controller.UserGroups.GetUserCount(group.Id, api.Controller.Users) >= group.MaxUsers {
+			api.exitWithError(w, http.StatusForbidden, "This tier is full")
+			return
+		}
+		user.AddGroup(request.GroupId)
+		api.Controller.Users.Update(user)
+		api.Controller.Users.Write(api.Controller.Database)
+		api.Controller.SyncConfigToFile()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"added": true})
+		return
+	}
+
+	if group.BillingMode != "all_users" {
+		api.exitWithError(w, http.StatusBadRequest, "Tier is not available for self-service subscription")
+		return
+	}
+	validPrice := false
+	for _, o := range group.GetPricingOptions() {
+		if o.PriceId == request.PriceId {
+			validPrice = true
+			break
+		}
+	}
+	if !validPrice {
+		api.exitWithError(w, http.StatusBadRequest, "Invalid price for tier")
+		return
+	}
+	// Already a paid member? (Membership without a subscription item is stale and
+	// allowed to proceed so it can be (re)billed.)
+	if user.IsMemberOf(request.GroupId) && api.userPaysForGroup(user, group) {
+		api.exitWithError(w, http.StatusBadRequest, "You are already subscribed to this tier")
+		return
+	}
+	// Block paid self-add when the user's customer is a group-shared customer.
+	if primary := api.Controller.UserGroups.Get(user.UserGroupId); primary != nil && primary.BillingMode == "group_admin" {
+		api.exitWithError(w, http.StatusBadRequest, "Your billing is managed by a group admin; paid tiers cannot be self-added")
+		return
+	}
+
+	stripe.Key = api.Controller.Options.StripeSecretKey
+	if stripe.Key == "" {
+		api.exitWithError(w, http.StatusBadRequest, "Billing is not configured")
+		return
+	}
+
+	// Branch A: active/trialing subscription → add a line item with proration.
+	if user.StripeSubscriptionId != "" {
+		if sub, err := subscription.Get(user.StripeSubscriptionId, nil); err == nil &&
+			(sub.Status == "active" || sub.Status == "trialing") {
+			if _, err := subscriptionitem.New(&stripe.SubscriptionItemParams{
+				Subscription:      stripe.String(sub.ID),
+				Price:             stripe.String(request.PriceId),
+				Quantity:          stripe.Int64(1),
+				ProrationBehavior: stripe.String("create_prorations"),
+			}); err != nil {
+				api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to add tier: %v", err))
+				return
+			}
+			if updated, e := subscription.Get(sub.ID, nil); e == nil {
+				sub = updated
+			}
+			api.reconcilePaidMembershipsFromSubscription(user, sub)
+			user.PinExpiresAt = api.calculatePinExpiration(sub, false)
+			api.Controller.Users.Update(user)
+			api.Controller.Users.Write(api.Controller.Database)
+			api.Controller.SyncConfigToFile()
+			log.Printf("Added tier %q to user %s via subscription item (proration)", group.Name, user.Email)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{"added": true})
+			return
+		}
+	}
+
+	// Branch B: no active subscription → client must complete a combined checkout
+	// (via /api/stripe/create-checkout-session with items).
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"added":         false,
+		"needsCheckout": true,
+		"groupId":       group.Id,
+		"priceId":       request.PriceId,
+		"email":         user.Email,
+	})
+}
+
+// userPaysForGroup reports whether one of the group's prices is on the user's
+// current subscription.
+func (api *Api) userPaysForGroup(user *User, group *UserGroup) bool {
+	if user == nil || group == nil || user.StripeSubscriptionId == "" || api.Controller.Options.StripeSecretKey == "" {
+		return false
+	}
+	stripe.Key = api.Controller.Options.StripeSecretKey
+	sub, err := subscription.Get(user.StripeSubscriptionId, nil)
+	if err != nil || sub.Items == nil {
+		return false
+	}
+	priceSet := map[string]bool{}
+	for _, o := range group.GetPricingOptions() {
+		priceSet[o.PriceId] = true
+	}
+	for _, item := range sub.Items.Data {
+		if item != nil && item.Price != nil && priceSet[item.Price.ID] {
+			return true
+		}
+	}
+	return false
+}
+
+// SubscriptionGroupRemoveHandler removes a paid tier: it deletes the matching
+// subscription item (proration) or cancels the whole subscription when it is the
+// last item.
+func (api *Api) SubscriptionGroupRemoveHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		api.exitWithError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	user := api.userFromRequestPin(r)
+	if user == nil {
+		api.exitWithError(w, http.StatusUnauthorized, "PIN required")
+		return
+	}
+	var request struct {
+		GroupId uint64 `json:"groupId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		api.exitWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+	group := api.Controller.UserGroups.Get(request.GroupId)
+	if group == nil || !group.IsSelfBillable() {
+		api.exitWithError(w, http.StatusBadRequest, "Tier cannot be self-removed")
+		return
+	}
+	if !user.IsMemberOf(request.GroupId) {
+		api.exitWithError(w, http.StatusBadRequest, "You are not a member of this tier")
+		return
+	}
+	// The primary/home group cannot be self-removed if it is the user's only tier.
+	if user.UserGroupId == request.GroupId && len(user.GroupIds()) <= 1 {
+		api.exitWithError(w, http.StatusBadRequest, "You cannot leave your only tier")
+		return
+	}
+
+	// Free tier: membership-only removal, no Stripe.
+	if !group.BillingEnabled {
+		user.RemoveGroup(request.GroupId)
+		api.Controller.Users.Update(user)
+		api.Controller.Users.Write(api.Controller.Database)
+		api.Controller.SyncConfigToFile()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"removed": true})
+		return
+	}
+
+	if group.BillingMode != "all_users" {
+		api.exitWithError(w, http.StatusBadRequest, "Tier cannot be self-removed")
+		return
+	}
+	if user.StripeSubscriptionId == "" || api.Controller.Options.StripeSecretKey == "" {
+		// No active subscription — just drop the (unbilled) membership.
+		user.RemoveGroup(request.GroupId)
+		api.Controller.Users.Update(user)
+		api.Controller.Users.Write(api.Controller.Database)
+		api.Controller.SyncConfigToFile()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"removed": true})
+		return
+	}
+
+	stripe.Key = api.Controller.Options.StripeSecretKey
+	sub, err := subscription.Get(user.StripeSubscriptionId, nil)
+	if err != nil || sub.Items == nil {
+		api.exitWithError(w, http.StatusBadRequest, "Could not load subscription")
+		return
+	}
+	// Find the subscription item whose price belongs to the group.
+	priceSet := map[string]bool{}
+	for _, o := range group.GetPricingOptions() {
+		priceSet[o.PriceId] = true
+	}
+	var itemId string
+	for _, item := range sub.Items.Data {
+		if item != nil && item.Price != nil && priceSet[item.Price.ID] {
+			itemId = item.ID
+			break
+		}
+	}
+	if itemId == "" {
+		api.exitWithError(w, http.StatusBadRequest, "This tier is not on your subscription")
+		return
+	}
+
+	if len(sub.Items.Data) <= 1 {
+		// Last item → cancel the whole subscription.
+		if _, err := subscription.Cancel(sub.ID, nil); err != nil {
+			api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to cancel subscription: %v", err))
+			return
+		}
+		user.StripeSubscriptionId = ""
+		user.SubscriptionStatus = "canceled"
+		user.RemoveGroup(request.GroupId)
+		// Drop any remaining paid all_users memberships (none are billed anymore).
+		for _, gid := range user.GroupIds() {
+			if g := api.Controller.UserGroups.Get(gid); g != nil && g.BillingEnabled && g.BillingMode == "all_users" {
+				user.RemoveGroup(gid)
+			}
+		}
+		api.Controller.Users.Update(user)
+		api.Controller.Users.Write(api.Controller.Database)
+		api.Controller.SyncConfigToFile()
+		log.Printf("Removed last tier %q for user %s → subscription canceled", group.Name, user.Email)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"removed": true, "canceled": true})
+		return
+	}
+
+	// Not the last item → delete just this item with proration.
+	if _, err := subscriptionitem.Del(itemId, &stripe.SubscriptionItemParams{
+		ProrationBehavior: stripe.String("create_prorations"),
+	}); err != nil {
+		api.exitWithError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to remove tier: %v", err))
+		return
+	}
+	if updated, e := subscription.Get(sub.ID, nil); e == nil {
+		sub = updated
+	}
+	api.reconcilePaidMembershipsFromSubscription(user, sub)
+	user.PinExpiresAt = api.calculatePinExpiration(sub, false)
+	api.Controller.Users.Update(user)
+	api.Controller.Users.Write(api.Controller.Database)
+	api.Controller.SyncConfigToFile()
+	log.Printf("Removed tier %q from user %s via subscription item deletion", group.Name, user.Email)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"removed": true})
 }
 
 // AccountRequestEmailChangeVerificationHandler handles POST requests to request email change verification code
@@ -5357,7 +5893,7 @@ func (api *Api) GroupAdminRemoveUserHandler(w http.ResponseWriter, r *http.Reque
 	// Move user to public registration group or remove group assignment
 	publicGroup := api.Controller.UserGroups.GetPublicRegistrationGroup()
 	if publicGroup != nil {
-		targetUser.UserGroupId = publicGroup.Id
+		targetUser.SetGroupIds([]uint64{publicGroup.Id})
 		// Clear user's individual delay settings - they will use the group's delay settings
 		api.clearUserDelayValues(targetUser)
 		// Sync user's connection limit with the group's connection limit
@@ -5635,7 +6171,7 @@ func (api *Api) GroupAdminAddUserHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Add user to group
-	user.UserGroupId = group.Id
+	user.SetGroupIds([]uint64{group.Id})
 	// Clear user's individual delay settings - they will use the group's delay settings
 	api.clearUserDelayValues(user)
 	// Sync user's connection limit with the group's connection limit
@@ -5734,7 +6270,7 @@ func (api *Api) GroupAdminAddExistingUserHandler(w http.ResponseWriter, r *http.
 	}
 
 	// Move user to new group
-	user.UserGroupId = group.Id
+	user.SetGroupIds([]uint64{group.Id})
 	// Clear user's individual delay settings - they will use the group's delay settings
 	api.clearUserDelayValues(user)
 	api.Controller.Users.Update(user)
@@ -6563,16 +7099,8 @@ func (api *Api) AdminCreateGroupHandler(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// If setting as public registration, unset any existing public registration group
-	if request.IsPublicRegistration {
-		existingPublic := api.Controller.UserGroups.GetPublicRegistrationGroup()
-		if existingPublic != nil {
-			existingPublic.IsPublicRegistration = false
-			api.Controller.UserGroups.Update(existingPublic, api.Controller.Database)
-			// Sync config to file if enabled
-			api.Controller.SyncConfigToFile()
-		}
-	}
+	// Multiple public registration tiers are supported — no longer unset the
+	// existing public group when flagging this one public.
 
 	// Set default billing mode if not provided
 	billingMode := request.BillingMode
@@ -6622,7 +7150,7 @@ func (api *Api) AdminCreateGroupHandler(w http.ResponseWriter, r *http.Request) 
 
 		// Ensure user is in the group
 		if user.UserGroupId != group.Id {
-			user.UserGroupId = group.Id
+			user.SetGroupIds([]uint64{group.Id})
 			// Clear user's individual delay settings - they will use the group's delay settings
 			api.clearUserDelayValues(user)
 		}
@@ -6873,16 +7401,8 @@ func (api *Api) AdminUpdateGroupHandler(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// If setting as public registration, unset any existing public registration group
-	if request.IsPublicRegistration && !group.IsPublicRegistration {
-		existingPublic := api.Controller.UserGroups.GetPublicRegistrationGroup()
-		if existingPublic != nil && existingPublic.Id != group.Id {
-			existingPublic.IsPublicRegistration = false
-			api.Controller.UserGroups.Update(existingPublic, api.Controller.Database)
-			// Sync config to file if enabled
-			api.Controller.SyncConfigToFile()
-		}
-	}
+	// Multiple public registration tiers are supported — no longer unset any
+	// other public group when flagging this one public.
 
 	oldBillingEnabled := group.BillingEnabled
 
@@ -7009,7 +7529,7 @@ func (api *Api) AdminAssignGroupAdminHandler(w http.ResponseWriter, r *http.Requ
 
 	// Ensure user is in the group
 	if user.UserGroupId != group.Id {
-		user.UserGroupId = group.Id
+		user.SetGroupIds([]uint64{group.Id})
 		// Clear user's individual delay settings - they will use the group's delay settings
 		api.clearUserDelayValues(user)
 	}
@@ -7780,7 +8300,7 @@ func (api *Api) AdminTransferUserHandler(w http.ResponseWriter, r *http.Request)
 	if targetUser.IsGroupAdmin {
 		targetUser.IsGroupAdmin = false
 	}
-	targetUser.UserGroupId = toGroup.Id
+	targetUser.SetGroupIds([]uint64{toGroup.Id})
 	// Clear user's individual delay settings - they will use the group's delay settings
 	api.clearUserDelayValues(targetUser)
 	// Sync user's connection limit with the group's connection limit
@@ -7850,7 +8370,7 @@ func (api *Api) GroupAdminRequestTransferHandler(w http.ResponseWriter, r *http.
 
 		// Update user group
 		oldGroupId := targetUser.UserGroupId
-		targetUser.UserGroupId = toGroup.Id
+		targetUser.SetGroupIds([]uint64{toGroup.Id})
 		// Remove group admin status if user was a group admin in the old group
 		if targetUser.IsGroupAdmin && oldGroupId > 0 {
 			targetUser.IsGroupAdmin = false
@@ -7917,7 +8437,7 @@ func (api *Api) GroupAdminRequestTransferHandler(w http.ResponseWriter, r *http.
 
 		// Update user group
 		oldGroupId := targetUser.UserGroupId
-		targetUser.UserGroupId = toGroup.Id
+		targetUser.SetGroupIds([]uint64{toGroup.Id})
 		// Remove group admin status if user was a group admin in the old group
 		if targetUser.IsGroupAdmin && oldGroupId > 0 {
 			targetUser.IsGroupAdmin = false
@@ -8040,7 +8560,7 @@ func (api *Api) GroupAdminApproveTransferHandler(w http.ResponseWriter, r *http.
 
 		// Update user group
 		oldGroupId := targetUser.UserGroupId
-		targetUser.UserGroupId = group.Id
+		targetUser.SetGroupIds([]uint64{group.Id})
 		// Remove group admin status if user was a group admin in the old group
 		if targetUser.IsGroupAdmin && oldGroupId > 0 {
 			targetUser.IsGroupAdmin = false
@@ -8188,7 +8708,7 @@ func (api *Api) GroupAdminApproveTransferLinkHandler(w http.ResponseWriter, r *h
 
 	// Update user group
 	oldGroupId := targetUser.UserGroupId
-	targetUser.UserGroupId = toGroup.Id
+	targetUser.SetGroupIds([]uint64{toGroup.Id})
 	// Remove group admin status if user was a group admin in the old group
 	if targetUser.IsGroupAdmin && oldGroupId > 0 {
 		targetUser.IsGroupAdmin = false
@@ -8644,7 +9164,7 @@ func (api *Api) UserTransferToPublicHandler(w http.ResponseWriter, r *http.Reque
 
 	// Update user group
 	oldGroupId := user.UserGroupId
-	user.UserGroupId = publicGroup.Id
+	user.SetGroupIds([]uint64{publicGroup.Id})
 	// Remove group admin status if user was a group admin in the old group
 	if user.IsGroupAdmin && oldGroupId > 0 {
 		user.IsGroupAdmin = false
@@ -8681,80 +9201,87 @@ func (api *Api) PublicRegistrationInfoHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	publicGroup := api.Controller.UserGroups.GetPublicRegistrationGroup()
-	if publicGroup == nil {
+	publicGroups := api.Controller.UserGroups.GetPublicRegistrationGroups()
+	if len(publicGroups) == 0 {
 		api.exitWithError(w, http.StatusNotFound, "Public registration group not found")
 		return
 	}
 
-	// Get pricing options
-	pricingOptions := publicGroup.GetPricingOptions()
+	// Build a tier per public group with pricing + an access summary.
+	tiers := make([]map[string]interface{}, 0, len(publicGroups))
+	for _, g := range publicGroups {
+		channels := api.groupAvailableChannels(g)
+		talkgroupCount := 0
+		for _, sys := range channels {
+			if tgs, ok := sys["talkgroups"].([]map[string]interface{}); ok {
+				talkgroupCount += len(tgs)
+			}
+		}
+		tiers = append(tiers, map[string]interface{}{
+			"groupId":        g.Id,
+			"name":           g.Name,
+			"description":    g.Description,
+			"billingEnabled": g.BillingEnabled,
+			"billingMode":    g.BillingMode,
+			"selfBillable":   g.IsSelfBillable(),
+			"pricingOptions": g.GetPricingOptions(),
+			"systemCount":    len(channels),
+			"talkgroupCount": talkgroupCount,
+		})
+	}
 
+	// Legacy top-level fields (first tier) for clients that predate multi-tier.
+	first := publicGroups[0]
 	response := map[string]interface{}{
-		"name":           publicGroup.Name,
-		"description":    publicGroup.Description,
-		"billingEnabled": publicGroup.BillingEnabled,
-		"pricingOptions": pricingOptions,
+		"name":           first.Name,
+		"description":    first.Description,
+		"billingEnabled": first.BillingEnabled,
+		"pricingOptions": first.GetPricingOptions(),
+		"tiers":          tiers,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
 
-// PublicRegistrationChannelsHandler returns available systems/channels for the public registration group
-func (api *Api) PublicRegistrationChannelsHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		api.exitWithError(w, http.StatusMethodNotAllowed, "Method not allowed")
-		return
-	}
-
-	publicGroup := api.Controller.UserGroups.GetPublicRegistrationGroup()
-	if publicGroup == nil {
-		api.exitWithError(w, http.StatusNotFound, "Public registration group not found")
-		return
-	}
-
-	// Get all systems
-	allSystems := api.Controller.Systems.List
+// groupAvailableChannels returns the systems (each with its accessible
+// talkgroups) that the given group grants, sorted for display.
+func (api *Api) groupAvailableChannels(group *UserGroup) []map[string]interface{} {
 	availableSystems := []map[string]interface{}{}
-
-	for _, system := range allSystems {
-		// Check if this system is accessible to the public group
-		if publicGroup.HasSystemAccess(uint64(system.SystemRef)) {
-			// Get talkgroups for this system, filtered by group access
-			talkgroups := []map[string]interface{}{}
-			for _, tg := range system.Talkgroups.List {
-				// Check if this talkgroup is accessible
-				if publicGroup.HasTalkgroupAccess(uint64(system.SystemRef), tg.TalkgroupRef) {
-					// Get tag for sorting
-					tagLabel := ""
-					if tg.TagId > 0 {
-						if tag, ok := api.Controller.Tags.GetTagById(tg.TagId); ok {
-							tagLabel = tag.Label
-						}
-					}
-					talkgroups = append(talkgroups, map[string]interface{}{
-						"id":          tg.TalkgroupRef,
-						"label":       tg.Label,
-						"name":        tg.Name,
-						"description": tg.Name,  // Use name as description
-						"tag":         tagLabel, // Alpha tag
-					})
+	if group == nil {
+		return availableSystems
+	}
+	for _, system := range api.Controller.Systems.List {
+		if !group.HasSystemAccess(uint64(system.SystemRef)) {
+			continue
+		}
+		talkgroups := []map[string]interface{}{}
+		for _, tg := range system.Talkgroups.List {
+			if !group.HasTalkgroupAccess(uint64(system.SystemRef), tg.TalkgroupRef) {
+				continue
+			}
+			tagLabel := ""
+			if tg.TagId > 0 {
+				if tag, ok := api.Controller.Tags.GetTagById(tg.TagId); ok {
+					tagLabel = tag.Label
 				}
 			}
-
-			// Only add system if it has accessible talkgroups
-			if len(talkgroups) > 0 {
-				availableSystems = append(availableSystems, map[string]interface{}{
-					"id":         system.SystemRef,
-					"label":      system.Label,
-					"talkgroups": talkgroups,
-				})
-			}
+			talkgroups = append(talkgroups, map[string]interface{}{
+				"id":          tg.TalkgroupRef,
+				"label":       tg.Label,
+				"name":        tg.Name,
+				"description": tg.Name,
+				"tag":         tagLabel,
+			})
+		}
+		if len(talkgroups) > 0 {
+			availableSystems = append(availableSystems, map[string]interface{}{
+				"id":         system.SystemRef,
+				"label":      system.Label,
+				"talkgroups": talkgroups,
+			})
 		}
 	}
-
-	// Sort systems by label, then sort talkgroups by tag then label
 	for _, sys := range availableSystems {
 		if talkgroups, ok := sys["talkgroups"].([]map[string]interface{}); ok {
 			sort.Slice(talkgroups, func(i, j int) bool {
@@ -8763,22 +9290,44 @@ func (api *Api) PublicRegistrationChannelsHandler(w http.ResponseWriter, r *http
 				if tagI != tagJ {
 					return tagI < tagJ
 				}
-				labelI := talkgroups[i]["label"].(string)
-				labelJ := talkgroups[j]["label"].(string)
-				return labelI < labelJ
+				return talkgroups[i]["label"].(string) < talkgroups[j]["label"].(string)
 			})
 		}
 	}
-
-	// Sort systems by label
 	sort.Slice(availableSystems, func(i, j int) bool {
-		labelI := availableSystems[i]["label"].(string)
-		labelJ := availableSystems[j]["label"].(string)
-		return labelI < labelJ
+		return availableSystems[i]["label"].(string) < availableSystems[j]["label"].(string)
 	})
+	return availableSystems
+}
+
+// PublicRegistrationChannelsHandler returns available systems/channels for a
+// public registration tier. Pass ?groupId= to target a specific tier; without
+// it, the first public group is summarized (back-compat).
+func (api *Api) PublicRegistrationChannelsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		api.exitWithError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	var group *UserGroup
+	if v := strings.TrimSpace(r.URL.Query().Get("groupId")); v != "" {
+		if id, err := strconv.ParseUint(v, 10, 64); err == nil {
+			if g := api.Controller.UserGroups.Get(id); g != nil && g.IsPublicRegistration {
+				group = g
+			}
+		}
+	}
+	if group == nil {
+		group = api.Controller.UserGroups.GetPublicRegistrationGroup()
+	}
+	if group == nil {
+		api.exitWithError(w, http.StatusNotFound, "Public registration group not found")
+		return
+	}
 
 	response := map[string]interface{}{
-		"systems": availableSystems,
+		"groupId": group.Id,
+		"systems": api.groupAvailableChannels(group),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/central_webhooks.go
+++ b/server/central_webhooks.go
@@ -104,9 +104,9 @@ func (api *Api) CentralWebhookUserGrantHandler(w http.ResponseWriter, r *http.Re
 			}
 		}
 
-		// Update user group
+		// Update user group (move to the single central-managed group).
 		if req.GroupID != nil {
-			existingUser.UserGroupId = *req.GroupID
+			existingUser.SetGroupIds([]uint64{*req.GroupID})
 		}
 
 		// Update in-memory map first.
@@ -114,7 +114,7 @@ func (api *Api) CentralWebhookUserGrantHandler(w http.ResponseWriter, r *http.Re
 
 		// Write directly to the DB for this specific user — targeted and reliable.
 		_, dbErr := api.Controller.Database.Sql.Exec(
-			`UPDATE "users" SET "pin"=$1, "pinExpiresAt"=$2, "connectionLimit"=$3, "firstName"=$4, "lastName"=$5, "systems"=$6, "talkgroups"=$7, "userGroupId"=$8, "verified"=$9 WHERE "userId"=$10`,
+			`UPDATE "users" SET "pin"=$1, "pinExpiresAt"=$2, "connectionLimit"=$3, "firstName"=$4, "lastName"=$5, "systems"=$6, "talkgroups"=$7, "userGroupId"=$8, "verified"=$9, "userGroupIds"=$10 WHERE "userId"=$11`,
 			existingUser.Pin,
 			int64(existingUser.PinExpiresAt),
 			int64(existingUser.ConnectionLimit),
@@ -124,6 +124,7 @@ func (api *Api) CentralWebhookUserGrantHandler(w http.ResponseWriter, r *http.Re
 			existingUser.Talkgroups,
 			existingUser.UserGroupId,
 			existingUser.Verified,
+			existingUser.UserGroupIds,
 			existingUser.Id,
 		)
 		if dbErr != nil {
@@ -177,7 +178,7 @@ func (api *Api) CentralWebhookUserGrantHandler(w http.ResponseWriter, r *http.Re
 
 	// Set user group
 	if req.GroupID != nil {
-		user.UserGroupId = *req.GroupID
+		user.SetGroupIds([]uint64{*req.GroupID})
 	}
 
 	// Add user to database

--- a/server/client.go
+++ b/server/client.go
@@ -647,7 +647,7 @@ func (clients *Clients) RefreshConfigForGroup(controller *Controller, groupId ui
 	count := len(clients.Map)
 
 	for c := range clients.Map {
-		if c.User != nil && c.User.UserGroupId == groupId {
+		if c.User != nil && c.User.IsMemberOf(groupId) {
 			if restricted {
 				if c.User == nil {
 					// Non-blocking send to prevent deadlock

--- a/server/controller.go
+++ b/server/controller.go
@@ -3672,33 +3672,53 @@ func (controller *Controller) readAllData() error {
 }
 
 // Helper method to check if user has access to a call (uses group settings if available)
+// userGroups resolves all of a user's group memberships to live *UserGroup.
+func (controller *Controller) userGroups(user *User) []*UserGroup {
+	if user == nil {
+		return nil
+	}
+	ids := user.GroupIds()
+	groups := make([]*UserGroup, 0, len(ids))
+	for _, id := range ids {
+		if g := controller.UserGroups.Get(id); g != nil {
+			groups = append(groups, g)
+		}
+	}
+	return groups
+}
+
+// groupsGrantAccess reports whether ANY of the user's groups grants access to
+// the system (and talkgroup when present). With multiple memberships a user's
+// access is the UNION of their groups. Returns true when the user has no groups
+// (no group ceiling to apply).
+func (controller *Controller) groupsGrantAccess(user *User, systemRef uint, talkgroup *Talkgroup) bool {
+	groups := controller.userGroups(user)
+	if len(groups) == 0 {
+		return true
+	}
+	for _, group := range groups {
+		if !group.HasSystemAccess(uint64(systemRef)) {
+			continue
+		}
+		if talkgroup != nil && !group.HasTalkgroupAccess(uint64(systemRef), talkgroup.TalkgroupRef) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func (controller *Controller) userHasAccess(user *User, call *Call) bool {
 	if user == nil || call == nil || call.System == nil {
 		return true
 	}
 
-	// Check group access first if user has a group
-	if user.UserGroupId > 0 {
-		group := controller.UserGroups.Get(user.UserGroupId)
-		if group != nil {
-			// Check if group has access to the system
-			if !group.HasSystemAccess(uint64(call.System.SystemRef)) {
-				return false
-			}
-
-			// CRITICAL: Also check talkgroup-level access if talkgroup exists
-			if call.Talkgroup != nil {
-				if !group.HasTalkgroupAccess(uint64(call.System.SystemRef), call.Talkgroup.TalkgroupRef) {
-					return false
-				}
-			}
-
-			// Group allows this system and talkgroup
-			// Still check user-level restrictions (user can be more restrictive than group)
-		}
+	// Group access is a ceiling: any group granting the system+talkgroup is enough.
+	if !controller.groupsGrantAccess(user, call.System.SystemRef, call.Talkgroup) {
+		return false
 	}
 
-	// Check user-level access (can further restrict access beyond group)
+	// Check user-level access (can further restrict access beyond the groups)
 	return user.HasAccess(call)
 }
 
@@ -3717,9 +3737,16 @@ func (controller *Controller) userHasSystemScopeAccess(user *User, systemRef uin
 	if user == nil || systemRef == 0 {
 		return false
 	}
-	if user.UserGroupId > 0 {
-		group := controller.UserGroups.Get(user.UserGroupId)
-		if group != nil && !group.HasSystemAccess(uint64(systemRef)) {
+	groups := controller.userGroups(user)
+	if len(groups) > 0 {
+		granted := false
+		for _, group := range groups {
+			if group.HasSystemAccess(uint64(systemRef)) {
+				granted = true
+				break
+			}
+		}
+		if !granted {
 			return false
 		}
 	}
@@ -3753,16 +3780,26 @@ func (controller *Controller) userEffectiveDelay(user *User, call *Call, default
 		return defaultDelay
 	}
 
-	// Check group delays first if user has a group
-	if user.UserGroupId > 0 {
-		group := controller.UserGroups.Get(user.UserGroupId)
-		if group != nil {
-			groupDelay := group.EffectiveDelay(call, defaultDelay)
-			// If group has a delay, use it (group settings override user settings)
-			if groupDelay != defaultDelay || group.Delay > 0 || len(group.systemDelaysMap) > 0 || len(group.talkgroupDelaysMap) > 0 {
-				return groupDelay
+	// Across the groups that actually grant access to this call, use the most
+	// permissive (minimum) configured group delay. Fall back to the user's own
+	// delay when no group configures one.
+	best := defaultDelay
+	found := false
+	for _, group := range controller.userGroups(user) {
+		if !group.HasSystemAccess(uint64(call.System.SystemRef)) ||
+			!group.HasTalkgroupAccess(uint64(call.System.SystemRef), call.Talkgroup.TalkgroupRef) {
+			continue
+		}
+		groupDelay := group.EffectiveDelay(call, defaultDelay)
+		if groupDelay != defaultDelay || group.Delay > 0 || len(group.systemDelaysMap) > 0 || len(group.talkgroupDelaysMap) > 0 {
+			if !found || groupDelay < best {
+				best = groupDelay
+				found = true
 			}
 		}
+	}
+	if found {
+		return best
 	}
 
 	// Fall back to user-level delays
@@ -3775,13 +3812,16 @@ func (controller *Controller) userEffectiveConnectionLimit(user *User) uint {
 		return 0
 	}
 
-	// Check group connection limit first if user has a group
-	if user.UserGroupId > 0 {
-		group := controller.UserGroups.Get(user.UserGroupId)
-		if group != nil && group.ConnectionLimit > 0 {
-			// Group connection limit overrides user limit
-			return group.ConnectionLimit
+	// Across a user's groups, take the most generous (maximum) group connection
+	// limit; fall back to the user's own limit when no group sets one.
+	best := uint(0)
+	for _, group := range controller.userGroups(user) {
+		if group.ConnectionLimit > best {
+			best = group.ConnectionLimit
 		}
+	}
+	if best > 0 {
+		return best
 	}
 
 	// Fall back to user-level connection limit

--- a/server/database.go
+++ b/server/database.go
@@ -277,6 +277,11 @@ func (db *Database) migrate() error {
 		return formatError(err, "")
 	}
 
+	// Migrate users userGroupIds column (multi-group membership)
+	if err := migrateUserGroupIds(db); err != nil {
+		return formatError(err, "")
+	}
+
 	// Migrate users mobile setup token (one-time app sign-in link)
 	if err := migrateUserMobileSetupToken(db); err != nil {
 		return formatError(err, "")

--- a/server/main.go
+++ b/server/main.go
@@ -654,6 +654,8 @@ func main() {
 	http.HandleFunc("/api/account/password/verify-code", wrapHandler(http.HandlerFunc(controller.Api.AccountVerifyPasswordChangeCodeHandler)).ServeHTTP)
 	http.HandleFunc("/api/account/password", wrapHandler(http.HandlerFunc(controller.Api.AccountUpdatePasswordHandler)).ServeHTTP)
 	http.HandleFunc("/api/billing/portal", wrapHandler(http.HandlerFunc(controller.Api.BillingPortalSessionHandler)).ServeHTTP)
+	http.HandleFunc("/api/subscription/groups/add", wrapHandler(http.HandlerFunc(controller.Api.SubscriptionGroupAddHandler)).ServeHTTP)
+	http.HandleFunc("/api/subscription/groups/remove", wrapHandler(http.HandlerFunc(controller.Api.SubscriptionGroupRemoveHandler)).ServeHTTP)
 
 	// Log that routes have been registered
 	log.Printf("All HTTP routes registered successfully")

--- a/server/migrations.go
+++ b/server/migrations.go
@@ -1887,6 +1887,23 @@ func migrateUserForcePasswordReset(db *Database) error {
 	return nil
 }
 
+// migrateUserGroupIds adds the userGroupIds column (JSON array of all groups a
+// user belongs to) and backfills existing single-group users to [userGroupId].
+func migrateUserGroupIds(db *Database) error {
+	queries := []string{
+		`ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "userGroupIds" text NOT NULL DEFAULT ''`,
+		// Backfill: users with a primary group but no membership array get [primary].
+		`UPDATE "users" SET "userGroupIds" = '[' || "userGroupId" || ']'
+			WHERE ("userGroupIds" IS NULL OR "userGroupIds" = '') AND "userGroupId" > 0`,
+	}
+	for _, query := range queries {
+		if _, err := db.Sql.Exec(query); err != nil {
+			log.Printf("migration note: %v", err)
+		}
+	}
+	return nil
+}
+
 // migrateUserGroupsPricingOptions adds pricingOptions column to userGroups table
 func migrateUserGroupsPricingOptions(db *Database) error {
 	query := `ALTER TABLE "userGroups" ADD COLUMN IF NOT EXISTS "pricingOptions" text NOT NULL DEFAULT ''`

--- a/server/system.go
+++ b/server/system.go
@@ -449,35 +449,49 @@ func (systems *Systems) GetScopedSystems(client *Client, groups *Groups, tags *T
 
 	user := client.User
 
-	// Get user's group if they belong to one
-	var userGroup *UserGroup
-	if user != nil && user.UserGroupId > 0 && client.Controller != nil {
-		userGroup = client.Controller.UserGroups.Get(user.UserGroupId)
+	// Resolve all of the user's group memberships; visible scope is the UNION.
+	var memberGroups []*UserGroup
+	if user != nil && client.Controller != nil {
+		memberGroups = client.Controller.userGroups(user)
 	}
 
-	// Helper function to check if a system is allowed
+	// Helper: a system is allowed when the user has no groups, or ANY group grants it.
 	isSystemAllowed := func(systemRef uint) bool {
-		// If user belongs to a group, check group access first
-		if userGroup != nil {
-			return userGroup.HasSystemAccess(uint64(systemRef))
+		if len(memberGroups) == 0 {
+			return true
 		}
-		// No group restrictions
-		return true
+		for _, g := range memberGroups {
+			if g.HasSystemAccess(uint64(systemRef)) {
+				return true
+			}
+		}
+		return false
 	}
 
-	// Helper function to filter talkgroups based on group restrictions
+	// Helper: a talkgroup is allowed when the user has no groups, or ANY group grants it.
+	groupAllowsTalkgroup := func(systemRef uint, talkgroupRef uint) bool {
+		if len(memberGroups) == 0 {
+			return true
+		}
+		for _, g := range memberGroups {
+			if g.HasTalkgroupAccess(uint64(systemRef), talkgroupRef) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Helper function to filter talkgroups based on group restrictions (union)
 	filterTalkgroupsByGroup := func(system *System) *System {
-		// If no group restrictions, return system as-is
-		if userGroup == nil {
+		if len(memberGroups) == 0 {
 			return system
 		}
 
-		// Filter talkgroups based on group access
 		filteredSystem := *system
 		filteredSystem.Talkgroups = NewTalkgroups()
 
 		for _, tg := range system.Talkgroups.List {
-			if userGroup.HasTalkgroupAccess(uint64(system.SystemRef), tg.TalkgroupRef) {
+			if groupAllowsTalkgroup(system.SystemRef, tg.TalkgroupRef) {
 				filteredSystem.Talkgroups.List = append(filteredSystem.Talkgroups.List, tg)
 			}
 		}
@@ -562,8 +576,8 @@ func (systems *Systems) GetScopedSystems(client *Client, groups *Groups, tags *T
 							if !ok {
 								continue
 							}
-							// Check group access for this talkgroup
-							if userGroup != nil && !userGroup.HasTalkgroupAccess(uint64(system.SystemRef), rawTalkgroup.TalkgroupRef) {
+							// Check group access for this talkgroup (union across groups)
+							if !groupAllowsTalkgroup(system.SystemRef, rawTalkgroup.TalkgroupRef) {
 								continue
 							}
 							rawSystem.Talkgroups.List = append(rawSystem.Talkgroups.List, rawTalkgroup)

--- a/server/user.go
+++ b/server/user.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,7 +53,8 @@ type User struct {
 	StripeCustomerId          string
 	StripeSubscriptionId      string
 	SubscriptionStatus        string
-	UserGroupId               uint64
+	UserGroupId               uint64 // Primary/home group (group-admin role, invitation default, back-compat)
+	UserGroupIds              string // JSON array of all group IDs the user belongs to; always contains UserGroupId
 	IsGroupAdmin              bool
 	SystemAdmin               bool // System administrator flag
 	PushSystemNoAudioAlerts   bool   // Push for assigned system no-audio alerts (in addition to system admins)
@@ -77,6 +79,8 @@ type User struct {
 	apiKeyNoAudioAlertIds     map[uint64]bool
 	systemNoAudioAlertAll     bool
 	apiKeyNoAudioAlertAll     bool
+	userGroupIdsList          []uint64 // union membership, primary first (parsed cache)
+	userGroupIdsSet           map[uint64]bool
 }
 
 type Users struct {
@@ -289,6 +293,163 @@ func (u *User) loadNoAudioAlertScopes() {
 	} else if raw != "" && raw != "[]" {
 		u.apiKeyNoAudioAlertIds = parseUserIdListJSON(raw)
 	}
+}
+
+// loadGroupMemberships (re)derives the membership caches from the current
+// UserGroupId + UserGroupIds and rewrites UserGroupIds to its canonical form so
+// the in-memory raw string always matches the caches. Call this on load and
+// before persisting.
+func (u *User) loadGroupMemberships() {
+	u.applyGroupIds(u.canonicalGroupIds())
+}
+
+// canonicalGroupIds derives the authoritative membership list (primary first,
+// remaining ids sorted for determinism) from UserGroupId + the parsed
+// UserGroupIds array:
+//   - 0 and duplicates are dropped;
+//   - if the primary group is set but ABSENT from a non-empty array, the array
+//     is treated as stale from a legacy single-group reassignment and membership
+//     collapses to just the primary (every multi-group mutation keeps the
+//     primary in the array, so absence means the scalar was changed directly);
+//   - otherwise membership = primary first, then the rest of the array.
+func (u *User) canonicalGroupIds() []uint64 {
+	seen := map[uint64]bool{}
+	raw := strings.TrimSpace(u.UserGroupIds)
+	if raw != "" && raw != "[]" {
+		for id := range parseUserIdListJSON(raw) {
+			if id != 0 {
+				seen[id] = true
+			}
+		}
+	}
+	primary := u.UserGroupId
+	if primary == 0 {
+		others := make([]uint64, 0, len(seen))
+		for id := range seen {
+			others = append(others, id)
+		}
+		sort.Slice(others, func(i, j int) bool { return others[i] < others[j] })
+		return others
+	}
+	if len(seen) > 0 && !seen[primary] {
+		return []uint64{primary} // stale array from a legacy scalar reassignment
+	}
+	others := make([]uint64, 0, len(seen))
+	for id := range seen {
+		if id != primary {
+			others = append(others, id)
+		}
+	}
+	sort.Slice(others, func(i, j int) bool { return others[i] < others[j] })
+	return append([]uint64{primary}, others...)
+}
+
+// applyGroupIds writes an already-canonical ordered list into the caches and the
+// raw JSON string.
+func (u *User) applyGroupIds(ordered []uint64) {
+	set := make(map[uint64]bool, len(ordered))
+	for _, id := range ordered {
+		set[id] = true
+	}
+	u.userGroupIdsSet = set
+	u.userGroupIdsList = ordered
+	if len(ordered) == 0 {
+		u.UserGroupIds = ""
+		return
+	}
+	if b, err := json.Marshal(ordered); err == nil {
+		u.UserGroupIds = string(b)
+	}
+}
+
+// GroupIds returns every group the user belongs to, primary first.
+func (u *User) GroupIds() []uint64 {
+	if u == nil {
+		return nil
+	}
+	if u.userGroupIdsSet == nil {
+		u.loadGroupMemberships()
+	}
+	out := make([]uint64, len(u.userGroupIdsList))
+	copy(out, u.userGroupIdsList)
+	return out
+}
+
+// IsMemberOf reports whether the user belongs to the given group.
+func (u *User) IsMemberOf(groupId uint64) bool {
+	if u == nil || groupId == 0 {
+		return false
+	}
+	if u.userGroupIdsSet == nil {
+		u.loadGroupMemberships()
+	}
+	return u.userGroupIdsSet[groupId]
+}
+
+// SetGroupIds replaces the full membership set. Duplicates and 0 are dropped.
+// The primary (UserGroupId) is preserved if still present, else reassigned to
+// the first id (or 0 when empty); the stored order is primary-first.
+func (u *User) SetGroupIds(ids []uint64) {
+	seen := map[uint64]bool{}
+	clean := []uint64{}
+	for _, id := range ids {
+		if id != 0 && !seen[id] {
+			seen[id] = true
+			clean = append(clean, id)
+		}
+	}
+	if u.UserGroupId == 0 || !seen[u.UserGroupId] {
+		if len(clean) > 0 {
+			u.UserGroupId = clean[0]
+		} else {
+			u.UserGroupId = 0
+		}
+	}
+	others := make([]uint64, 0, len(clean))
+	for _, id := range clean {
+		if id != u.UserGroupId {
+			others = append(others, id)
+		}
+	}
+	sort.Slice(others, func(i, j int) bool { return others[i] < others[j] })
+	ordered := []uint64{}
+	if u.UserGroupId != 0 {
+		ordered = append(ordered, u.UserGroupId)
+	}
+	ordered = append(ordered, others...)
+	u.applyGroupIds(ordered)
+}
+
+// AddGroup adds a group to the membership set (primary unchanged).
+func (u *User) AddGroup(groupId uint64) {
+	if groupId == 0 || u.IsMemberOf(groupId) {
+		return
+	}
+	u.SetGroupIds(append(u.GroupIds(), groupId))
+}
+
+// RemoveGroup removes a group; if it was the primary, a remaining group becomes
+// primary (or none when the set empties).
+func (u *User) RemoveGroup(groupId uint64) {
+	if groupId == 0 || !u.IsMemberOf(groupId) {
+		return
+	}
+	next := []uint64{}
+	for _, g := range u.GroupIds() {
+		if g != groupId {
+			next = append(next, g)
+		}
+	}
+	if u.UserGroupId == groupId {
+		u.UserGroupId = 0 // let SetGroupIds choose a new primary
+	}
+	u.SetGroupIds(next)
+}
+
+// SetPrimaryGroup makes groupId the primary/home group, adding it to membership.
+func (u *User) SetPrimaryGroup(groupId uint64) {
+	u.UserGroupId = groupId
+	u.SetGroupIds(append(u.GroupIds(), groupId))
 }
 
 func parseUserIdListJSON(raw string) map[uint64]bool {
@@ -831,6 +992,7 @@ func (users *Users) Update(user *User) error {
 	user.ensurePinsLoaded()
 	user.loadSystemScopes()
 	user.loadNoAudioAlertScopes()
+	user.loadGroupMemberships() // keep the membership cache in sync with UserGroupId/UserGroupIds
 	user.loadDelayMaps()
 
 	var oldEmailForRelay, newEmailForRelay string
@@ -906,7 +1068,7 @@ func (users *Users) Read(db *Database) error {
 	users.pins = make(map[string]*User)
 	users.groupAdmins = make(map[uint64]*User)
 
-	rows, err := db.Sql.Query(`SELECT "userId", "email", "password", "pin", "pinExpiresAt", "connectionLimit", "verified", "verificationToken", "createdAt", "lastLogin", "firstName", "lastName", "zipCode", "systems", "talkgroups", "delay", "systemDelays", "talkgroupDelays", "settings", "stripeCustomerId", "stripeSubscriptionId", "subscriptionStatus", "userGroupId", "isGroupAdmin", COALESCE("systemAdmin", false), COALESCE("pushSystemNoAudioAlerts", false), COALESCE("pushApiKeyNoAudioAlerts", false), COALESCE("systemNoAudioAlertSystems", ''), COALESCE("apiKeyNoAudioAlertApiKeys", ''), COALESCE("forcePasswordReset", false), "resetCode", "resetCodeExpires", "accountExpiresAt", COALESCE("mobileSetupTokenHash", ''), COALESCE("mobileSetupTokenExpires", 0), COALESCE("mobileWelcomeEmailSent", false) FROM "users"`)
+	rows, err := db.Sql.Query(`SELECT "userId", "email", "password", "pin", "pinExpiresAt", "connectionLimit", "verified", "verificationToken", "createdAt", "lastLogin", "firstName", "lastName", "zipCode", "systems", "talkgroups", "delay", "systemDelays", "talkgroupDelays", "settings", "stripeCustomerId", "stripeSubscriptionId", "subscriptionStatus", "userGroupId", "isGroupAdmin", COALESCE("userGroupIds", ''), COALESCE("systemAdmin", false), COALESCE("pushSystemNoAudioAlerts", false), COALESCE("pushApiKeyNoAudioAlerts", false), COALESCE("systemNoAudioAlertSystems", ''), COALESCE("apiKeyNoAudioAlertApiKeys", ''), COALESCE("forcePasswordReset", false), "resetCode", "resetCodeExpires", "accountExpiresAt", COALESCE("mobileSetupTokenHash", ''), COALESCE("mobileSetupTokenExpires", 0), COALESCE("mobileWelcomeEmailSent", false) FROM "users"`)
 	if err != nil {
 		return formatError(err, "")
 	}
@@ -922,6 +1084,7 @@ func (users *Users) Read(db *Database) error {
 		var stripeCustomerId, stripeSubscriptionId, subscriptionStatus sql.NullString
 		var userGroupId sql.NullInt64
 		var isGroupAdmin sql.NullBool
+		var userGroupIds sql.NullString
 		var systemAdmin sql.NullBool
 		var pushSystemNoAudioAlerts sql.NullBool
 		var pushApiKeyNoAudioAlerts sql.NullBool
@@ -935,7 +1098,7 @@ func (users *Users) Read(db *Database) error {
 		var mobileSetupTokenExpires sql.NullInt64
 		var mobileWelcomeEmailSent sql.NullBool
 
-		err := rows.Scan(&user.Id, &user.Email, &user.Password, &pin, &pinExpiresAt, &connectionLimit, &user.Verified, &user.VerificationToken, &user.CreatedAt, &user.LastLogin, &user.FirstName, &user.LastName, &user.ZipCode, &systems, &talkgroups, &user.Delay, &systemDelays, &talkgroupDelays, &settings, &stripeCustomerId, &stripeSubscriptionId, &subscriptionStatus, &userGroupId, &isGroupAdmin, &systemAdmin, &pushSystemNoAudioAlerts, &pushApiKeyNoAudioAlerts, &systemNoAudioAlertSystems, &apiKeyNoAudioAlertApiKeys, &forcePasswordReset, &resetCode, &resetCodeExpires, &accountExpiresAt, &mobileSetupTokenHash, &mobileSetupTokenExpires, &mobileWelcomeEmailSent)
+		err := rows.Scan(&user.Id, &user.Email, &user.Password, &pin, &pinExpiresAt, &connectionLimit, &user.Verified, &user.VerificationToken, &user.CreatedAt, &user.LastLogin, &user.FirstName, &user.LastName, &user.ZipCode, &systems, &talkgroups, &user.Delay, &systemDelays, &talkgroupDelays, &settings, &stripeCustomerId, &stripeSubscriptionId, &subscriptionStatus, &userGroupId, &isGroupAdmin, &userGroupIds, &systemAdmin, &pushSystemNoAudioAlerts, &pushApiKeyNoAudioAlerts, &systemNoAudioAlertSystems, &apiKeyNoAudioAlertApiKeys, &forcePasswordReset, &resetCode, &resetCodeExpires, &accountExpiresAt, &mobileSetupTokenHash, &mobileSetupTokenExpires, &mobileWelcomeEmailSent)
 		if err != nil {
 			return formatError(err, "")
 		}
@@ -979,6 +1142,9 @@ func (users *Users) Read(db *Database) error {
 		}
 		if isGroupAdmin.Valid {
 			user.IsGroupAdmin = isGroupAdmin.Bool
+		}
+		if userGroupIds.Valid {
+			user.UserGroupIds = userGroupIds.String
 		}
 		if systemAdmin.Valid {
 			user.SystemAdmin = systemAdmin.Bool
@@ -1024,6 +1190,7 @@ func (users *Users) Read(db *Database) error {
 		user.ensurePinsLoaded()
 		user.loadSystemScopes()
 		user.loadNoAudioAlertScopes()
+		user.loadGroupMemberships()
 		user.loadDelayMaps()
 
 		users.users[user.Id] = user
@@ -1062,6 +1229,8 @@ func (users *Users) Write(db *Database) error {
 		stripeSubscriptionId := user.StripeSubscriptionId
 		subscriptionStatus := user.SubscriptionStatus
 		user.ensurePinsLoaded()
+		user.loadGroupMemberships() // canonicalize UserGroupIds before persisting
+		userGroupIds := user.UserGroupIds
 		pin := user.Pin
 		pinExpiresAt := int64(user.PinExpiresAt)
 		connectionLimit := int64(user.ConnectionLimit)
@@ -1116,8 +1285,8 @@ func (users *Users) Write(db *Database) error {
 				accountExpiresAtVal = int64(0)
 			}
 
-			result, err := db.Sql.Exec(`INSERT INTO "users" ("email", "password", "pin", "pinExpiresAt", "connectionLimit", "verified", "verificationToken", "createdAt", "lastLogin", "firstName", "lastName", "zipCode", "systems", "talkgroups", "delay", "systemDelays", "talkgroupDelays", "settings", "stripeCustomerId", "stripeSubscriptionId", "subscriptionStatus", "userGroupId", "isGroupAdmin", "systemAdmin", "pushSystemNoAudioAlerts", "pushApiKeyNoAudioAlerts", "systemNoAudioAlertSystems", "apiKeyNoAudioAlertApiKeys", "forcePasswordReset", "resetCode", "resetCodeExpires", "accountExpiresAt", "mobileSetupTokenHash", "mobileSetupTokenExpires", "mobileWelcomeEmailSent") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)`,
-				user.Email, user.Password, pin, pinExpiresAt, connectionLimit, user.Verified, user.VerificationToken, createdAtStr, lastLoginStr, user.FirstName, user.LastName, user.ZipCode, systems, talkgroups, user.Delay, systemDelays, talkgroupDelays, settings, stripeCustomerId, stripeSubscriptionId, subscriptionStatus, user.UserGroupId, user.IsGroupAdmin, user.SystemAdmin, user.PushSystemNoAudioAlerts, user.PushApiKeyNoAudioAlerts, user.SystemNoAudioAlertSystems, user.ApiKeyNoAudioAlertApiKeys, user.ForcePasswordReset, resetCodeVal, resetCodeExpiresVal, accountExpiresAtVal, user.MobileSetupTokenHash, int64(user.MobileSetupTokenExpires), user.MobileWelcomeEmailSent)
+			result, err := db.Sql.Exec(`INSERT INTO "users" ("email", "password", "pin", "pinExpiresAt", "connectionLimit", "verified", "verificationToken", "createdAt", "lastLogin", "firstName", "lastName", "zipCode", "systems", "talkgroups", "delay", "systemDelays", "talkgroupDelays", "settings", "stripeCustomerId", "stripeSubscriptionId", "subscriptionStatus", "userGroupId", "isGroupAdmin", "systemAdmin", "pushSystemNoAudioAlerts", "pushApiKeyNoAudioAlerts", "systemNoAudioAlertSystems", "apiKeyNoAudioAlertApiKeys", "forcePasswordReset", "resetCode", "resetCodeExpires", "accountExpiresAt", "mobileSetupTokenHash", "mobileSetupTokenExpires", "mobileWelcomeEmailSent", "userGroupIds") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36)`,
+				user.Email, user.Password, pin, pinExpiresAt, connectionLimit, user.Verified, user.VerificationToken, createdAtStr, lastLoginStr, user.FirstName, user.LastName, user.ZipCode, systems, talkgroups, user.Delay, systemDelays, talkgroupDelays, settings, stripeCustomerId, stripeSubscriptionId, subscriptionStatus, user.UserGroupId, user.IsGroupAdmin, user.SystemAdmin, user.PushSystemNoAudioAlerts, user.PushApiKeyNoAudioAlerts, user.SystemNoAudioAlertSystems, user.ApiKeyNoAudioAlertApiKeys, user.ForcePasswordReset, resetCodeVal, resetCodeExpiresVal, accountExpiresAtVal, user.MobileSetupTokenHash, int64(user.MobileSetupTokenExpires), user.MobileWelcomeEmailSent, userGroupIds)
 			if err != nil {
 				return formatError(err, "")
 			}
@@ -1176,8 +1345,8 @@ func (users *Users) Write(db *Database) error {
 				accountExpiresAtVal = int64(0)
 			}
 
-			_, err = db.Sql.Exec(`UPDATE "users" SET "email"=$1, "password"=$2, "pin"=$3, "pinExpiresAt"=$4, "connectionLimit"=$5, "verified"=$6, "verificationToken"=$7, "createdAt"=$8, "lastLogin"=$9, "firstName"=$10, "lastName"=$11, "zipCode"=$12, "systems"=$13, "talkgroups"=$14, "delay"=$15, "systemDelays"=$16, "talkgroupDelays"=$17, "settings"=$18, "stripeCustomerId"=$19, "stripeSubscriptionId"=$20, "subscriptionStatus"=$21, "userGroupId"=$22, "isGroupAdmin"=$23, "systemAdmin"=$24, "pushSystemNoAudioAlerts"=$25, "pushApiKeyNoAudioAlerts"=$26, "systemNoAudioAlertSystems"=$27, "apiKeyNoAudioAlertApiKeys"=$28, "forcePasswordReset"=$29, "resetCode"=$30, "resetCodeExpires"=$31, "accountExpiresAt"=$32, "mobileSetupTokenHash"=$33, "mobileSetupTokenExpires"=$34, "mobileWelcomeEmailSent"=$35 WHERE "userId"=$36`,
-				user.Email, user.Password, pin, pinExpiresAt, connectionLimit, user.Verified, user.VerificationToken, createdAtStr, lastLoginStr, user.FirstName, user.LastName, user.ZipCode, systems, talkgroups, user.Delay, systemDelays, talkgroupDelays, settings, stripeCustomerId, stripeSubscriptionId, subscriptionStatus, user.UserGroupId, user.IsGroupAdmin, user.SystemAdmin, user.PushSystemNoAudioAlerts, user.PushApiKeyNoAudioAlerts, user.SystemNoAudioAlertSystems, user.ApiKeyNoAudioAlertApiKeys, user.ForcePasswordReset, resetCodeVal, resetCodeExpiresVal, accountExpiresAtVal, user.MobileSetupTokenHash, int64(user.MobileSetupTokenExpires), user.MobileWelcomeEmailSent, user.Id)
+			_, err = db.Sql.Exec(`UPDATE "users" SET "email"=$1, "password"=$2, "pin"=$3, "pinExpiresAt"=$4, "connectionLimit"=$5, "verified"=$6, "verificationToken"=$7, "createdAt"=$8, "lastLogin"=$9, "firstName"=$10, "lastName"=$11, "zipCode"=$12, "systems"=$13, "talkgroups"=$14, "delay"=$15, "systemDelays"=$16, "talkgroupDelays"=$17, "settings"=$18, "stripeCustomerId"=$19, "stripeSubscriptionId"=$20, "subscriptionStatus"=$21, "userGroupId"=$22, "isGroupAdmin"=$23, "systemAdmin"=$24, "pushSystemNoAudioAlerts"=$25, "pushApiKeyNoAudioAlerts"=$26, "systemNoAudioAlertSystems"=$27, "apiKeyNoAudioAlertApiKeys"=$28, "forcePasswordReset"=$29, "resetCode"=$30, "resetCodeExpires"=$31, "accountExpiresAt"=$32, "mobileSetupTokenHash"=$33, "mobileSetupTokenExpires"=$34, "mobileWelcomeEmailSent"=$35, "userGroupIds"=$36 WHERE "userId"=$37`,
+				user.Email, user.Password, pin, pinExpiresAt, connectionLimit, user.Verified, user.VerificationToken, createdAtStr, lastLoginStr, user.FirstName, user.LastName, user.ZipCode, systems, talkgroups, user.Delay, systemDelays, talkgroupDelays, settings, stripeCustomerId, stripeSubscriptionId, subscriptionStatus, user.UserGroupId, user.IsGroupAdmin, user.SystemAdmin, user.PushSystemNoAudioAlerts, user.PushApiKeyNoAudioAlerts, user.SystemNoAudioAlertSystems, user.ApiKeyNoAudioAlertApiKeys, user.ForcePasswordReset, resetCodeVal, resetCodeExpiresVal, accountExpiresAtVal, user.MobileSetupTokenHash, int64(user.MobileSetupTokenExpires), user.MobileWelcomeEmailSent, userGroupIds, user.Id)
 			if err != nil {
 				return formatError(err, "")
 			}
@@ -1287,6 +1456,7 @@ func (users *Users) SaveNewUser(user *User, db *Database) error {
 	formatError := errorFormatter("users", "saveNewUser")
 
 	user.ensurePinsLoaded()
+	user.loadGroupMemberships() // canonicalize UserGroupIds before insert
 
 	// All these columns are NOT NULL, so use empty string instead of NULL
 	systems := user.Systems
@@ -1328,14 +1498,15 @@ func (users *Users) SaveNewUser(user *User, db *Database) error {
 	}
 
 	// Insert user with all fields including systems, delays, settings, and Stripe data
-	err := db.Sql.QueryRow(`INSERT INTO "users" ("email", "password", "pin", "pinExpiresAt", "connectionLimit", "verified", "verificationToken", "createdAt", "lastLogin", "firstName", "lastName", "zipCode", "systems", "talkgroups", "delay", "systemDelays", "talkgroupDelays", "settings", "stripeCustomerId", "stripeSubscriptionId", "subscriptionStatus", "accountExpiresAt", "userGroupId", "isGroupAdmin", "systemAdmin", "pushSystemNoAudioAlerts", "pushApiKeyNoAudioAlerts", "systemNoAudioAlertSystems", "apiKeyNoAudioAlertApiKeys", "forcePasswordReset", "mobileSetupTokenHash", "mobileSetupTokenExpires", "mobileWelcomeEmailSent") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33) RETURNING "userId"`,
-		user.Email, user.Password, user.Pin, user.PinExpiresAt, user.ConnectionLimit, user.Verified, user.VerificationToken, createdAtStr, lastLoginStr, user.FirstName, user.LastName, user.ZipCode, systems, user.Talkgroups, user.Delay, systemDelays, talkgroupDelays, settings, stripeCustomerId, stripeSubscriptionId, subscriptionStatus, user.AccountExpiresAt, user.UserGroupId, user.IsGroupAdmin, user.SystemAdmin, user.PushSystemNoAudioAlerts, user.PushApiKeyNoAudioAlerts, user.SystemNoAudioAlertSystems, user.ApiKeyNoAudioAlertApiKeys, user.ForcePasswordReset, user.MobileSetupTokenHash, int64(user.MobileSetupTokenExpires), user.MobileWelcomeEmailSent).Scan(&userId)
+	err := db.Sql.QueryRow(`INSERT INTO "users" ("email", "password", "pin", "pinExpiresAt", "connectionLimit", "verified", "verificationToken", "createdAt", "lastLogin", "firstName", "lastName", "zipCode", "systems", "talkgroups", "delay", "systemDelays", "talkgroupDelays", "settings", "stripeCustomerId", "stripeSubscriptionId", "subscriptionStatus", "accountExpiresAt", "userGroupId", "isGroupAdmin", "systemAdmin", "pushSystemNoAudioAlerts", "pushApiKeyNoAudioAlerts", "systemNoAudioAlertSystems", "apiKeyNoAudioAlertApiKeys", "forcePasswordReset", "mobileSetupTokenHash", "mobileSetupTokenExpires", "mobileWelcomeEmailSent", "userGroupIds") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34) RETURNING "userId"`,
+		user.Email, user.Password, user.Pin, user.PinExpiresAt, user.ConnectionLimit, user.Verified, user.VerificationToken, createdAtStr, lastLoginStr, user.FirstName, user.LastName, user.ZipCode, systems, user.Talkgroups, user.Delay, systemDelays, talkgroupDelays, settings, stripeCustomerId, stripeSubscriptionId, subscriptionStatus, user.AccountExpiresAt, user.UserGroupId, user.IsGroupAdmin, user.SystemAdmin, user.PushSystemNoAudioAlerts, user.PushApiKeyNoAudioAlerts, user.SystemNoAudioAlertSystems, user.ApiKeyNoAudioAlertApiKeys, user.ForcePasswordReset, user.MobileSetupTokenHash, int64(user.MobileSetupTokenExpires), user.MobileWelcomeEmailSent, user.UserGroupIds).Scan(&userId)
 	if err != nil {
 		return formatError(err, "")
 	}
 	user.Id = uint64(userId)
 	user.loadSystemScopes()
 	user.loadNoAudioAlertScopes()
+	user.loadGroupMemberships()
 	user.loadDelayMaps()
 
 	// Now add to memory with the real ID

--- a/server/user_group.go
+++ b/server/user_group.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -450,6 +451,31 @@ func (ugs *UserGroups) GetPublicRegistrationGroup() *UserGroup {
 	return nil
 }
 
+// GetPublicRegistrationGroups returns every group flagged as a public
+// registration tier, ordered by name for a stable signup listing.
+func (ugs *UserGroups) GetPublicRegistrationGroups() []*UserGroup {
+	ugs.mutex.RLock()
+	defer ugs.mutex.RUnlock()
+	out := []*UserGroup{}
+	for _, group := range ugs.groups {
+		if group.IsPublicRegistration {
+			out = append(out, group)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// IsSelfBillable reports whether a user can self-serve join/leave this group:
+// free groups, or paid groups billed per-user ("all_users"). Groups billed via
+// "group_admin" (a shared customer the admin pays) are excluded.
+func (ug *UserGroup) IsSelfBillable() bool {
+	if ug == nil {
+		return false
+	}
+	return !ug.BillingEnabled || ug.BillingMode == "all_users" || ug.BillingMode == ""
+}
+
 func (ugs *UserGroups) GetAll() []*UserGroup {
 	ugs.mutex.RLock()
 	defer ugs.mutex.RUnlock()
@@ -545,7 +571,7 @@ func (ugs *UserGroups) GetUserCount(groupId uint64, users *Users) uint {
 	defer users.mutex.RUnlock()
 
 	for _, user := range users.users {
-		if user.UserGroupId == groupId {
+		if user.IsMemberOf(groupId) {
 			count++
 		}
 	}


### PR DESCRIPTION
## Summary

Adds support for **multiple subscription tiers**. Two capabilities the current single-group model did not allow:

1. **Multiple public tiers** - more than one user group can be a public-registration tier, so a new user chooses which tier(s) to join at signup.
2. **Multi-group paid membership** - a user can belong to and pay for several groups at once, and add or remove tiers later, with Stripe reconciling automatically.

A user's access is the union of all their groups.

## Product decisions this implements

- Billing is **one combined Stripe subscription** with one line item per paid group. Add/remove is a subscription-item change with proration. All paid public tiers share one billing interval.
- Self-service is limited to `all_users`-billing and free groups. `group_admin`-billing groups stay admin-managed exactly as today.
- Existing subscribers add a tier by charging the saved card with proration server-side (no redirect); first-time subscribers go through Stripe Checkout.
- Combined checkout: longest trial across selected tiers, and automatic tax wins if any selected tier uses automatic tax.

## What changed

**Membership model (server)**
- New `users.userGroupIds` JSON column holds every group a user belongs to. `users.userGroupId` stays the primary/home group and is always contained in the set.
- Mutators in `server/user.go` (SetGroupIds, AddGroup, RemoveGroup, SetPrimaryGroup) plus canonicalize-on-load-and-persist keep the array and caches consistent. Every legacy single-group "move" handler (transfers, central-management webhook) now routes through SetGroupIds instead of writing the scalar directly.
- Idempotent migration adds the column and backfills existing users to `[userGroupId]`.

**Access union (server)**
- `controller.go` access, scope, delay (min), and connection-limit (max) helpers and `system.go` scoped systems now union across the user's groups. Existing user-level restrictions still apply on top.

**Public tiers and signup (server)**
- The single-public-group limit is removed. `/api/public-registration-info` returns a list of tiers with pricing and an access summary. `UserRegisterHandler` accepts `groupIds` + `primaryGroupId`, validates public + self-billable, and enforces per-group max users.

**Billing (server)**
- `CreateCheckoutSessionHandler` accepts `items[]` (one per paid group) or the legacy single `priceId`; builds one subscription with multiple line items.
- New `/api/subscription/groups/add` and `/api/subscription/groups/remove` do server-side subscription-item add/delete with proration, cancel the subscription when the last item is removed, and handle free tiers as membership-only. `/api/account` returns per-tier memberships and available tiers.
- The subscription webhook reconciles paid memberships from the subscription's line items so Billing Portal changes stay in sync.

**Client**
- Settings gains a "Your Tiers" panel with per-tier add/remove.
- Signup gains a multi-tier picker (with per-tier price selection) and drives a combined checkout for paid tiers.
- The admin user editor gains a group-memberships multi-select alongside the primary-group select.
- The Stripe checkout component supports posting combined `items`.

## Testing

Verified end-to-end against a local Postgres + server build (no Stripe test keys in this environment):

- Migration adds `userGroupIds` and backfills existing users.
- Two public groups both appear in `/api/public-registration-info`.
- Multi-tier signup persists `userGroupIds=[1,2]` with the chosen primary.
- Self-service add/remove of free tiers, primary reassignment on removing the primary tier, and the "cannot leave your only tier" guard all work; the live Settings "Your Tiers" panel add/remove was exercised in the browser with no console errors.
- Admin multi-group update persists correctly with no in-memory/DB divergence.
- Server builds clean (go build + go vet); client builds clean under production AOT.

An adversarial review of the diff found two real defects, both fixed in this branch: legacy move handlers that wrote the group scalar directly could silently drop a multi-tier user's other memberships, and a checkout change could have double-billed on Change Plan. Fixes route all move handlers through the membership mutators, persist `userGroupIds` in the central-webhook update, refresh the membership cache in `Users.Update`, and restore always-cancel-prior on checkout.

## Not covered

- The Stripe-billed paths (paid combined checkout, proration add/remove, webhook reconciliation) compile and follow the decisions above but were not runtime-tested here; exercise them with Stripe test-mode keys and `stripe listen` before production.
- An admin transfer that drops a still-billed paid tier does not yet remove that tier's Stripe line item; a later subscription webhook could re-add it. This is a narrow admin edge, noted for follow-up.

