### PR TITLE
Fix admin call-nature phrases being silently dropped on save

### DIFF
--- a/client/scripts/test-call-natures-save.js
+++ b/client/scripts/test-call-natures-save.js
@@ -1,0 +1,62 @@
+/**
+ * Lightweight node harness for call-nature saveEdit phrase commit behavior.
+ * Mirrors RdioScannerAdminCallNaturesComponent.saveEdit / addPhraseFromInput.
+ */
+function addPhraseFromInput(state) {
+  const text = (state.newPhraseText || '').trim();
+  if (!text) return state;
+  const phrase = text.toUpperCase();
+  const phrases = [...(state.phrases || [])];
+  if (!phrases.includes(phrase)) {
+    phrases.push(phrase);
+  }
+  return { ...state, phrases, newPhraseText: '' };
+}
+
+function buildPayload(state) {
+  // Commit pending phrase before save (the UI fix).
+  state = addPhraseFromInput(state);
+  return {
+    label: (state.label || '').toUpperCase().trim(),
+    phrases: (state.phrases || [])
+      .map((p) => p.toUpperCase().trim())
+      .filter((p) => p.length > 0),
+  };
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+// Case 1: typed phrase, Save without clicking Add
+{
+  const payload = buildPayload({
+    label: 'SHOTS FIRED',
+    phrases: ['SHOTS FIRED'],
+    newPhraseText: 'gunshots heard',
+  });
+  assert(payload.phrases.includes('GUNSHOTS HEARD'), 'pending phrase must be committed on save');
+  assert(payload.phrases.includes('SHOTS FIRED'), 'existing phrases kept');
+}
+
+// Case 2: empty pending box leaves phrases alone
+{
+  const payload = buildPayload({
+    label: 'STRUCTURE FIRE',
+    phrases: ['FIRE'],
+    newPhraseText: '   ',
+  });
+  assert(payload.phrases.length === 1 && payload.phrases[0] === 'FIRE', 'blank input must not mutate');
+}
+
+// Case 3: duplicate pending phrase is not double-added
+{
+  const payload = buildPayload({
+    label: 'ALARM',
+    phrases: ['ALARM DROP'],
+    newPhraseText: 'alarm drop',
+  });
+  assert(payload.phrases.length === 1, 'duplicate pending phrase must not duplicate');
+}
+
+console.log('call-natures frontend save harness: PASS');

--- a/client/src/app/components/rdio-scanner/admin/config/call-natures/call-natures.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/call-natures/call-natures.component.ts
@@ -123,7 +123,15 @@ export class RdioScannerAdminCallNaturesComponent implements OnInit, OnDestroy {
     }
 
     async saveEdit(): Promise<void> {
-        if (!this.editingForm || this.editingForm.invalid || this.editingIndex === null) {
+        if (!this.editingForm || this.editingIndex === null) {
+            return;
+        }
+
+        // Commit a phrase typed into the "Add phrase" box but not yet added via
+        // Enter/Add, so clicking Save directly doesn't silently drop it.
+        this.addPhraseFromInput();
+
+        if (this.editingForm.invalid) {
             return;
         }
 

--- a/server/api_call_natures.go
+++ b/server/api_call_natures.go
@@ -9,8 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"rdio-scanner/server/mapping"
+	"unicode/utf8"
 )
 
 // CallNaturesHandler handles GET/POST /api/call-natures
@@ -158,12 +157,29 @@ func stringsFromAnySlice(v any) []string {
 	return out
 }
 
+// maxManualCallNaturePhraseLen is a generous safety cap for admin-entered
+// phrases. Real dispatch phrases are far shorter; this only guards against a
+// pathological paste bloating the match terms.
+const maxManualCallNaturePhraseLen = 120
+
+// sanitizeCallNaturePhrases cleans phrases typed by an admin in the call-nature
+// editor: uppercase, trim, drop empty, dedup, and cap absurd lengths. It does
+// NOT apply mapping.IsAcceptableCallNaturePhrase — that heuristic is tuned for
+// automatic phrase mining (rejecting periods, "ON SCENE", >6 words, etc.) and
+// silently discarding an admin's explicit input is exactly the "phrases won't
+// save" bug. When an admin types a phrase, we trust it.
 func sanitizeCallNaturePhrases(phrases []string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, p := range phrases {
 		p = strings.ToUpper(strings.TrimSpace(p))
-		if p == "" || seen[p] || !mapping.IsAcceptableCallNaturePhrase(p) {
+		if p == "" {
+			continue
+		}
+		if utf8.RuneCountInString(p) > maxManualCallNaturePhraseLen {
+			p = strings.TrimSpace(string([]rune(p)[:maxManualCallNaturePhraseLen]))
+		}
+		if p == "" || seen[p] {
 			continue
 		}
 		seen[p] = true

--- a/server/api_call_natures_e2e_test.go
+++ b/server/api_call_natures_e2e_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2025 Thinline Dynamic Solutions
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"rdio-scanner/server/mapping"
+)
+
+// TestCallNaturePhraseSave_EndToEndRegression documents the two failure modes
+// that caused "phrases won't always save" and asserts the fixed pipeline
+// (client pending-commit + server admin sanitize) preserves them.
+func TestCallNaturePhraseSave_EndToEndRegression(t *testing.T) {
+	t.Parallel()
+
+	type step struct {
+		label         string
+		existing      []string
+		pendingInput  string // typed in "Add phrase" but Save clicked without Add
+		alreadyAdded  []string
+		wantPersisted []string
+	}
+
+	cases := []step{
+		{
+			label:         "SHOTS FIRED",
+			existing:      []string{"SHOTS FIRED"},
+			pendingInput:  "gunshots heard",
+			wantPersisted: []string{"SHOTS FIRED", "GUNSHOTS HEARD"},
+		},
+		{
+			label:         "STRUCTURE FIRE",
+			existing:      []string{"STRUCTURE FIRE"},
+			alreadyAdded:  []string{"UNIT ON SCENE"}, // mining heuristic used to drop this
+			wantPersisted: []string{"STRUCTURE FIRE", "UNIT ON SCENE"},
+		},
+		{
+			label:         "PERSON WITH GUN",
+			existing:      []string{"PERSON WITH GUN"},
+			alreadyAdded:  []string{"PERSON WITH A GUN IN THE PARKING LOT"},
+			wantPersisted: []string{"PERSON WITH GUN", "PERSON WITH A GUN IN THE PARKING LOT"},
+		},
+		{
+			label:         "ALARM DROP",
+			existing:      []string{"ALARM DROP"},
+			pendingInput:  "alarm drop.",
+			wantPersisted: []string{"ALARM DROP", "ALARM DROP."},
+		},
+		{
+			label:         "MEDICAL",
+			existing:      []string{"MEDICAL"},
+			alreadyAdded:  []string{"FIRE STATION RESPONSE", "PT COMPLAINING OF CHEST PAIN"},
+			wantPersisted: []string{"MEDICAL", "FIRE STATION RESPONSE", "PT COMPLAINING OF CHEST PAIN"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+
+			// --- Client: mirror addPhraseFromInput + saveEdit payload build ---
+			phrases := append([]string{}, tc.existing...)
+			phrases = append(phrases, tc.alreadyAdded...)
+			if pending := strings.ToUpper(strings.TrimSpace(tc.pendingInput)); pending != "" {
+				dup := false
+				for _, p := range phrases {
+					if p == pending {
+						dup = true
+						break
+					}
+				}
+				if !dup {
+					phrases = append(phrases, pending)
+				}
+			}
+			for i, p := range phrases {
+				phrases[i] = strings.ToUpper(strings.TrimSpace(p))
+			}
+
+			// Prove old mining filter would have dropped at least one of the
+			// non-label phrases in these regression cases (except the first,
+			// which is about pending-input commit).
+			if len(tc.alreadyAdded) > 0 || strings.Contains(tc.pendingInput, ".") {
+				var droppedByOld []string
+				for _, p := range phrases {
+					if p == tc.label {
+						continue
+					}
+					if !mapping.IsAcceptableCallNaturePhrase(p) {
+						droppedByOld = append(droppedByOld, p)
+					}
+				}
+				if len(droppedByOld) == 0 && (len(tc.alreadyAdded) > 0 || strings.Contains(tc.pendingInput, ".")) {
+					// pending "gunshots heard" is acceptable to mining; skip assert
+					if tc.pendingInput != "gunshots heard" {
+						t.Fatalf("expected mining heuristic to reject some phrases in this case; got none from %v", phrases)
+					}
+				}
+			}
+
+			// --- Server: admin sanitize (fixed) ---
+			persisted := sanitizeCallNaturePhrases(phrases)
+
+			if len(persisted) != len(tc.wantPersisted) {
+				t.Fatalf("persisted len=%d want %d\n got=%v\nwant=%v", len(persisted), len(tc.wantPersisted), persisted, tc.wantPersisted)
+			}
+			for i := range tc.wantPersisted {
+				if persisted[i] != tc.wantPersisted[i] {
+					t.Fatalf("idx %d: got %q want %q\nfull got=%v", i, persisted[i], tc.wantPersisted[i], persisted)
+				}
+			}
+
+			// --- JSON round-trip like POST/PUT body ---
+			body, err := json.Marshal(map[string]any{
+				"label":   tc.label,
+				"phrases": persisted,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(body, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			again := sanitizeCallNaturePhrases(stringsFromAnySlice(decoded["phrases"]))
+			if len(again) != len(persisted) {
+				t.Fatalf("json round-trip changed phrase count: %v -> %v", persisted, again)
+			}
+		})
+	}
+}

--- a/server/api_call_natures_live_test.go
+++ b/server/api_call_natures_live_test.go
@@ -1,0 +1,211 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"rdio-scanner/server/mapping"
+
+	_ "github.com/lib/pq"
+)
+
+// Live DB + handler path test. Run with:
+//
+//	go test -tags=integration -run TestLiveCallNaturePhraseSave -count=1 -v
+//
+// Requires Postgres (defaults: db tlr, user postgres, password postgres).
+func TestLiveCallNaturePhraseSave(t *testing.T) {
+	host := envOr("TLR_DB_HOST", "localhost")
+	port := envOr("TLR_DB_PORT", "5432")
+	name := envOr("TLR_DB_NAME", "tlr")
+	user := envOr("TLR_DB_USER", "postgres")
+	pass := envOr("TLR_DB_PASS", "postgres")
+
+	db, dbName, err := openPostgres(host, port, user, pass, name)
+	if err != nil {
+		t.Skipf("postgres not reachable: %v", err)
+	}
+	defer db.Close()
+	t.Logf("connected to database %q", dbName)
+
+	var exists bool
+	err = db.QueryRow(`SELECT EXISTS (
+		SELECT 1 FROM information_schema.tables WHERE table_name = 'callNatures'
+	)`).Scan(&exists)
+	if err != nil || !exists {
+		t.Skipf("callNatures table missing: %v", err)
+	}
+
+	label := fmt.Sprintf("E2E TEST %d", time.Now().UnixNano()%100000)
+	phrases := []string{
+		label,
+		"UNIT ON SCENE",
+		"PERSON WITH A GUN IN THE PARKING LOT",
+		"ALARM DROP.",
+		"FIRE STATION RESPONSE",
+	}
+	sanitized := sanitizeCallNaturePhrases(phrases)
+	if len(sanitized) != len(phrases) {
+		t.Fatalf("sanitize dropped phrases before insert: got %v", sanitized)
+	}
+	pj, _ := json.Marshal(sanitized)
+
+	var id int64
+	err = db.QueryRow(
+		`INSERT INTO "callNatures" ("label", "phrases", "enabled", "order", "expireMinutes", "createdAt")
+		 VALUES ($1, $2, true, 0, 0, $3) RETURNING "callNatureId"`,
+		label, string(pj), time.Now().UnixMilli(),
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM "callNatures" WHERE "callNatureId" = $1`, id)
+	})
+
+	var raw string
+	err = db.QueryRow(`SELECT "phrases" FROM "callNatures" WHERE "callNatureId" = $1`, id).Scan(&raw)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	var stored []string
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		t.Fatalf("unmarshal phrases %q: %v", raw, err)
+	}
+	for _, want := range phrases {
+		found := false
+		for _, s := range stored {
+			if s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("phrase %q missing from DB after save; stored=%v", want, stored)
+		}
+	}
+
+	bodyMap := map[string]any{
+		"label":   label,
+		"phrases": append(append([]string{}, stored...), "GUNSHOTS HEARD", "PT COMPLAINING OF CHEST PAIN"),
+	}
+	bodyBytes, _ := json.Marshal(bodyMap)
+	var decoded map[string]any
+	_ = json.Unmarshal(bodyBytes, &decoded)
+	updated := sanitizeCallNaturePhrases(stringsFromAnySlice(decoded["phrases"]))
+	wantExtra := []string{"GUNSHOTS HEARD", "PT COMPLAINING OF CHEST PAIN"}
+	for _, w := range wantExtra {
+		ok := false
+		for _, u := range updated {
+			if u == w {
+				ok = true
+			}
+		}
+		if !ok {
+			t.Fatalf("update sanitize lost %q; got %v", w, updated)
+		}
+	}
+	uj, _ := json.Marshal(updated)
+	_, err = db.Exec(
+		`UPDATE "callNatures" SET "phrases" = $1 WHERE "callNatureId" = $2`,
+		string(uj), id,
+	)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	err = db.QueryRow(`SELECT "phrases" FROM "callNatures" WHERE "callNatureId" = $1`, id).Scan(&raw)
+	if err != nil {
+		t.Fatalf("reselect: %v", err)
+	}
+	stored = nil
+	_ = json.Unmarshal([]byte(raw), &stored)
+	for _, w := range wantExtra {
+		found := false
+		for _, s := range stored {
+			if s == w {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("after update, %q missing; stored=%v", w, stored)
+		}
+	}
+
+	var keptByOld int
+	for _, p := range stored {
+		if mapping.IsAcceptableCallNaturePhrase(p) {
+			keptByOld++
+		}
+	}
+	if keptByOld >= len(stored) {
+		t.Fatalf("expected old mining filter to drop some of %v", stored)
+	}
+	t.Logf("live DB save OK id=%d phrases=%d (old filter would keep %d)", id, len(stored), keptByOld)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/call-natures/1", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	b, _ := io.ReadAll(req.Body)
+	var again map[string]any
+	if err := json.Unmarshal(b, &again); err != nil {
+		t.Fatal(err)
+	}
+	final := sanitizeCallNaturePhrases(stringsFromAnySlice(again["phrases"]))
+	if len(final) < 4 {
+		t.Fatalf("handler decode path lost phrases: %v", final)
+	}
+}
+
+func envOr(k, def string) string {
+	if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+		return v
+	}
+	return def
+}
+
+func openPostgres(host, port, user, pass, preferred string) (*sql.DB, string, error) {
+	try := []string{preferred, "tlr", "thinline_radio", "rdio_scanner", "postgres"}
+	seen := map[string]bool{}
+	var last error
+	for _, name := range try {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", host, port, user, pass, name)
+		db, err := sql.Open("postgres", dsn)
+		if err != nil {
+			last = err
+			continue
+		}
+		if err := db.Ping(); err != nil {
+			last = err
+			db.Close()
+			continue
+		}
+		return db, name, nil
+	}
+	// Also try empty password
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password= dbname=%s sslmode=disable", host, port, user, preferred)
+	db, err := sql.Open("postgres", dsn)
+	if err == nil && db.Ping() == nil {
+		return db, preferred, nil
+	}
+	if db != nil {
+		db.Close()
+	}
+	if last == nil {
+		last = err
+	}
+	return nil, "", last
+}

--- a/server/api_call_natures_test.go
+++ b/server/api_call_natures_test.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Thinline Dynamic Solutions
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeCallNaturePhrases_PreservesAdminInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "basic uppercase trim dedup",
+			in:   []string{"  shots fired ", "SHOTS FIRED", "structure fire"},
+			want: []string{"SHOTS FIRED", "STRUCTURE FIRE"},
+		},
+		{
+			name: "period previously rejected by mining heuristic",
+			in:   []string{"ALARM DROP."},
+			want: []string{"ALARM DROP."},
+		},
+		{
+			name: "on scene substring previously rejected",
+			in:   []string{"UNIT ON SCENE"},
+			want: []string{"UNIT ON SCENE"},
+		},
+		{
+			name: "more than six words previously rejected",
+			in:   []string{"PERSON WITH A GUN IN THE PARKING LOT"},
+			want: []string{"PERSON WITH A GUN IN THE PARKING LOT"},
+		},
+		{
+			name: "longer than mining max length previously rejected",
+			in:   []string{strings.Repeat("A", 60)},
+			want: []string{strings.Repeat("A", 60)},
+		},
+		{
+			name: "station substring previously rejected",
+			in:   []string{"FIRE STATION RESPONSE"},
+			want: []string{"FIRE STATION RESPONSE"},
+		},
+		{
+			name: "drops empty only",
+			in:   []string{"", "  ", "OK"},
+			want: []string{"OK"},
+		},
+		{
+			name: "caps pathological paste",
+			in:   []string{strings.Repeat("X", 200)},
+			want: []string{strings.Repeat("X", maxManualCallNaturePhraseLen)},
+		},
+		{
+			name: "short phrases still kept",
+			in:   []string{"AB", "ABC"},
+			want: []string{"AB", "ABC"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitizeCallNaturePhrases(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len=%d want %d; got=%v want=%v", len(got), len(tc.want), got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("idx %d: got %q want %q (full got=%v)", i, got[i], tc.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeCallNaturePhrases_DoesNotApplyMiningHeuristic(t *testing.T) {
+	t.Parallel()
+
+	// These are exactly the patterns IsAcceptableCallNaturePhrase rejects.
+	rejectedByMining := []string{
+		"ON SCENE CHECK",
+		"COMPLAINING OF CHEST PAIN",
+		"SHE'S ARMED",
+		"HE'S DOWN",
+		"THEY'RE FIGHTING",
+		"TIME OUT STATUS",
+		"CUSTOMER DISPUTE",
+		"WIFE IS INJURED",
+		"HUSBAND IS DOWN",
+		"HIT HIS HEAD",
+		"HIT HER ARM",
+		"C/O PAIN",
+		"UNKNOWN PROBLEM",
+		"45 YEAR OLD MALE",
+	}
+
+	got := sanitizeCallNaturePhrases(rejectedByMining)
+	if len(got) != len(rejectedByMining) {
+		t.Fatalf("admin sanitize dropped phrases; got %d want %d: %v", len(got), len(rejectedByMining), got)
+	}
+	for i, p := range rejectedByMining {
+		want := strings.ToUpper(strings.TrimSpace(p))
+		if got[i] != want {
+			t.Fatalf("idx %d: got %q want %q", i, got[i], want)
+		}
+	}
+}

--- a/server/mapping/call_nature_phrase_test.go
+++ b/server/mapping/call_nature_phrase_test.go
@@ -1,0 +1,35 @@
+package mapping
+
+import "testing"
+
+func TestIsAcceptableCallNaturePhrase_StillRejectsMiningNoise(t *testing.T) {
+	t.Parallel()
+
+	reject := []string{
+		"AB", // too short
+		"ALARM DROP.",
+		"UNIT ON SCENE", // contains " ON SCENE"
+		"PERSON WITH A GUN IN THE PARKING LOT", // >6 words
+		"UNKNOWN PROBLEM",
+		"45 YEAR OLD MALE",
+		"FIRE STATION RESPONSE", // contains " STATION "
+		"PT COMPLAINING OF CHEST PAIN", // contains " COMPLAINING OF"
+	}
+	for _, p := range reject {
+		if IsAcceptableCallNaturePhrase(p) {
+			t.Fatalf("mining heuristic should reject %q", p)
+		}
+	}
+
+	accept := []string{
+		"SHOTS FIRED",
+		"STRUCTURE FIRE",
+		"PERSON WITH GUN",
+		"ALARM DROP",
+	}
+	for _, p := range accept {
+		if !IsAcceptableCallNaturePhrase(p) {
+			t.Fatalf("mining heuristic should accept %q", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Admin call-nature phrase saves looked like they worked in the UI, but many phrases never persisted. The admin API was routing manual phrases through `IsAcceptableCallNaturePhrase`, a heuristic built for automatic phrase mining, which silently dropped valid admin input. Separately, typing a phrase into the Add phrase box and clicking Save without pressing Enter/Add left that text out of the payload. This PR stops filtering admin input with the mining heuristic and commits pending Add-phrase text on Save.

## What happened
Two independent silent-drop paths caused "phrases won't always save":

1. **Server sanitize used the mining heuristic** — `sanitizeCallNaturePhrases` called `mapping.IsAcceptableCallNaturePhrase`, which rejects periods, substrings like `ON SCENE` / `STATION` / `COMPLAINING OF`, phrases longer than 6 words or 48 characters, age patterns, and similar noise. That is correct for auto-learned transcript phrases, but wrong for an admin explicitly typing match terms. The API returned success while dropping the rejected phrases from the stored JSON.

2. **Client Save ignored the pending Add-phrase input** — Phrases only entered the form array via Enter or the Add button. Clicking Save with text still in the input box discarded that text without warning.

## What this PR fixes
**Server (`api_call_natures.go`):**
- Admin sanitize now only uppercases, trims, drops empties, dedupes, and caps absurd lengths (120 runes).
- Does **not** apply `IsAcceptableCallNaturePhrase` to admin API input.
- Auto-mining / backfill paths still use the mining heuristic unchanged.

**Client (`call-natures.component.ts`):**
- `saveEdit()` calls `addPhraseFromInput()` before validating/submitting so pending box text is committed.

**Tests:**
- Unit tests for admin sanitize preserving previously rejected phrases.
- Regression harness covering client pending-commit + server sanitize + JSON round-trip.
- Mapping test confirming the mining heuristic still rejects noise.
- Optional `-tags=integration` live Postgres insert/update test.
- Node harness for the frontend pending-Save behavior.

## Testing
Verified end-to-end against local Postgres + server build on current main:

- `go test . -run "TestSanitizeCallNaturePhrases|TestCallNaturePhraseSave_EndToEnd"` — pass.
- `go test ./mapping -run TestIsAcceptableCallNaturePhrase` — pass.
- `go test -tags=integration -run TestLiveCallNaturePhraseSave` — pass; phrases like `UNIT ON SCENE`, `ALARM DROP.`, and long multi-word phrases persisted (old filter would have kept only a subset).
- Live HTTP create/update/get/delete of previously rejected phrases — pass (create 5 → update 8 → get matches → delete).
- Production Angular build includes the Save pending-commit call.
- Manual browser click-through of admin Call Natures was started (login + open panel) but not fully completed for the Save-without-Add UI path.

## Deferred
- The generated `server/webapp/` bundle is not committed (built at release/Docker time).
- Consolidating admin validation UX (e.g. toast when a phrase would still be truncated by the length cap) can follow separately; the silent mining drop is the reported bug.
