### PR TITLE
Fix signup email locked empty after access/invite code

### DIFF
--- a/client/src/app/components/rdio-scanner/auth-screen/auth-screen.component.html
+++ b/client/src/app/components/rdio-scanner/auth-screen/auth-screen.component.html
@@ -408,8 +408,9 @@
 
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Email</mat-label>
-          <input matInput type="email" formControlName="email" required [readonly]="emailVerificationRequired && signupEmailCodeConfirmed">
-          <mat-hint *ngIf="emailVerificationRequired && signupEmailCodeConfirmed">Verified</mat-hint>
+          <input matInput type="email" formControlName="email" required autocomplete="email"
+                 [readonly]="emailLockedAfterVerify">
+          <mat-hint *ngIf="emailLockedAfterVerify">Verified</mat-hint>
           <mat-error *ngIf="registerForm.get('email')?.hasError('required')">
             Email is required
           </mat-error>

--- a/client/src/app/components/rdio-scanner/auth-screen/auth-screen.component.ts
+++ b/client/src/app/components/rdio-scanner/auth-screen/auth-screen.component.ts
@@ -90,6 +90,12 @@ export class RdioScannerAuthScreenComponent implements OnInit, OnDestroy, AfterV
   pendingEmail = '';
   /** True after user enters the 6-digit signup code (email-verification-required flow only). */
   signupEmailCodeConfirmed = false;
+  /**
+   * When true, the registration email input is read-only (OTP confirmed, or invite
+   * bound to a specific email). Access/invite codes without a bound email must NOT
+   * set this — that left an empty "Verified" field users could not type into (#261).
+   */
+  emailLockedAfterVerify = false;
   /** True when registration completed via an access/invitation code — user is auto-verified, no email check needed. */
   registeredWithCode = false;
   
@@ -345,10 +351,13 @@ export class RdioScannerAuthScreenComponent implements OnInit, OnDestroy, AfterV
           // Invitation link counts as email verification — skip the email code step
           this.signupEmailCodeConfirmed = true;
           
-          // Pre-fill email if provided in invitation
+          // Pre-fill email if provided in invitation; only lock when we have one
           if (response.email) {
             this.registerForm.patchValue({ email: response.email });
             this.pendingEmail = response.email;
+            this.emailLockedAfterVerify = true;
+          } else {
+            this.emailLockedAfterVerify = false;
           }
           
           // Set invitation code as accessCode
@@ -475,6 +484,7 @@ export class RdioScannerAuthScreenComponent implements OnInit, OnDestroy, AfterV
       this.pendingEmail = '';
       this.emailVerificationError = '';
       this.signupEmailCodeConfirmed = false;
+      this.emailLockedAfterVerify = false;
     }
     // Clear errors when switching modes
     if (mode !== 'group-admin') {
@@ -897,6 +907,7 @@ export class RdioScannerAuthScreenComponent implements OnInit, OnDestroy, AfterV
     this.emailVerificationError = '';
     this.emailVerificationStep = false;
     this.signupEmailCodeConfirmed = true;
+    this.emailLockedAfterVerify = !!this.pendingEmail;
     this.registerForm.patchValue({ email: this.pendingEmail });
     this.cdr.markForCheck();
     this.snackBar.open('Code accepted. Complete your registration below.', 'Close', {
@@ -911,6 +922,7 @@ export class RdioScannerAuthScreenComponent implements OnInit, OnDestroy, AfterV
     this.emailVerificationError = '';
     this.pendingEmail = '';
     this.signupEmailCodeConfirmed = false;
+    this.emailLockedAfterVerify = false;
     this.cdr.markForCheck();
   }
 
@@ -1201,12 +1213,16 @@ export class RdioScannerAuthScreenComponent implements OnInit, OnDestroy, AfterV
             accessCode: this.pendingAccessCode
           });
           
-          // If email was provided in invitation, pre-fill it
+          // Only lock email when the code is bound to a specific address.
+          // Generic access codes leave email empty and editable (#261).
           if (response.email) {
             this.registerForm.patchValue({
               email: response.email
             });
             this.pendingEmail = response.email;
+            this.emailLockedAfterVerify = true;
+          } else {
+            this.emailLockedAfterVerify = false;
           }
           
           this.snackBar.open('Code validated successfully!', 'Close', {


### PR DESCRIPTION
## Summary
Fixes #261. After entering an access/invite code on mobile signup, the Email field showed a **Verified** hint but stayed empty and read-only, so users could not type an address and Sign Up stayed disabled.

## What happened
Access/invite validation sets `signupEmailCodeConfirmed = true` so the email OTP step is skipped (codes count as verification). The full registration form then bound:

```html
[readonly]="emailVerificationRequired && signupEmailCodeConfirmed"
```

and showed a **Verified** hint whenever that was true.

For generic access codes (and invitations without a bound email), no address was pre-filled. The field was therefore empty, marked Verified, and `readonly` — on mobile it looked focusable but rejected input. Screenshot on the issue shows exactly that (red required Email + Verified under it).

## What this PR fixes
- Introduces `emailLockedAfterVerify`, set only when a real verified email is known:
  - after the 6-digit email OTP confirms `pendingEmail`
  - after invite/access validation **only if** the response includes an email
- Generic access/invite codes still skip the OTP step (`signupEmailCodeConfirmed`), but leave Email editable so the user can type.
- **Verified** hint and `readonly` both key off `emailLockedAfterVerify`, not the OTP-skip flag alone.

## Testing
- [ ] Invite-only / access code without bound email → after Validate, Email is empty, editable, no Verified hint; typing works on mobile; Sign Up enables after a valid email.
- [ ] Invitation/access code with bound email → Email pre-filled and locked with Verified (unchanged intended behavior).
- [ ] Email-verification-required public signup → request code → verify → Email locked to the confirmed address with Verified.
- [ ] Change email / switch auth tabs resets the lock flag.

## Deferred
- None.
