### PR TITLE
Fix Channels talkgroup list truncating labels (#262)

### DIFF
--- a/client/src/app/components/rdio-scanner/select/select.component.scss
+++ b/client/src/app/components/rdio-scanner/select/select.component.scss
@@ -852,26 +852,29 @@
 
 // ── Talkgroup grid ──────────────────────────────────────────────────────────
 //
-// Fixed 4 columns on desktop so each card is wide enough for the label +
-// description without ellipsis clipping ("Forestry Fire…"). Narrower viewports
-// step down to 3 → 2 → 1 column in the channels grid.
-// (both render `<rdio-scanner-select>`).
+// Column count must follow the *container* width, not the viewport. Channels
+// shares the panel with a ~336px systems rail (restored in 26.07.19), so a
+// viewport-based `repeat(4, …)` left each card ~160–220px and ellipsis clipped
+// talkgroup labels/names (#262). `auto-fill` + a readable min width collapses
+// to a single-column list when space is tight (same readability as Scan Lists
+// on a full-width pane) and packs multiple columns only when they fit.
 .talkgroup-list {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 6px;
   align-items: stretch;
+}
 
-  @media (max-width: 900px) {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+// Channels detail is narrower than Scan Lists — prefer a list layout so label,
+// secondary name, and TG id stay visible beside the systems rail.
+.channels-detail .talkgroup-list {
+  grid-template-columns: minmax(0, 1fr);
+}
 
-  @media (max-width: 680px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  @media (max-width: 420px) {
-    grid-template-columns: minmax(0, 1fr);
+@media (min-width: 1400px) {
+  // Wide window: allow a second column in channels when the detail pane is roomy.
+  .channels-detail .talkgroup-list {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes #262. Channel Selection was truncating talkgroup labels/names (e.g. `33911A…`, `33EL…`) after the ~26.07.19 layout restored a systems sidebar while the talkgroup grid still forced four viewport-based columns. This PR sizes columns from available container width and defaults Channels to a readable single-column list beside the systems rail.

## What happened
Around 26.07.19 the Channels panel regained a ~336px systems sidebar. Talkgroup cards still used `grid-template-columns: repeat(4, minmax(0, 1fr))` keyed to **viewport** breakpoints (4 → 3 → 2 → 1), not the remaining detail pane width. On a typical desktop window that left each card ~160–220px. Combined with ellipsis on `.row-label` / `.row-name`, labels and secondary names clipped even though the DOM still had the full strings (and TG id). Scan Lists looked fine because it uses the full panel width.

## What this PR fixes
- `.talkgroup-list` uses `repeat(auto-fill, minmax(260px, 1fr))` so column count follows container width instead of viewport.
- `.channels-detail .talkgroup-list` defaults to a single full-width column so label, name, and id stay visible next to the systems rail.
- At `min-width: 1400px`, Channels may pack additional columns with `minmax(280px, 1fr)` when the detail pane is wide enough.
- Removes the old viewport-only 4/3/2/1 media queries that caused the squeeze.

## Testing
- [ ] Open Channel Selection with a system that has long talkgroup labels/names.
- [ ] Confirm labels/names are not ellipsis-clipped beside the systems sidebar at normal desktop widths.
- [ ] Confirm Scan Lists still lays out talkgroups in a multi-column grid when space allows.
- [ ] Resize below/above ~1400px and confirm Channels stays list-like until there is room for a second column.
- [ ] Spot-check mobile/narrow widths: list remains usable (single column).

## Deferred
- Adding a separate description field/column is out of scope; the current row already shows label, secondary name, and TG id once width is adequate.
- Further container-query polish (`@container`) could refine breakpoints without viewport media queries; not required to fix #262.
