### PR TITLE
Revamp unit alias auto-learn with Accept/Dismiss review

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/admin.service.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.service.ts
@@ -527,6 +527,45 @@ export interface ToneHistoryAnalyzeResponse {
     message?: string;
 }
 
+export interface UnitAliasSuggestion {
+    candidateId: number;
+    systemId: number;
+    unitRef: number;
+    suggestedLabel: string;
+    reason?: string;
+    usedOpenAI: boolean;
+    sightings: number;
+    sampleCallIds?: number[];
+    sampleTranscript?: string;
+    firstSeenAt: number;
+    lastSeenAt: number;
+    ready: boolean;
+    talkgroupIds?: number[];
+}
+
+export interface UnitAliasLearnStatus {
+    enabled: boolean;
+    callsRequired: number;
+    pendingReady: number;
+    pendingAll: number;
+}
+
+export interface UnitAliasSuggestionsResponse {
+    status: UnitAliasLearnStatus;
+    suggestions: UnitAliasSuggestion[];
+}
+
+export interface UnitAliasScanResponse {
+    callsScanned: number;
+    callsWithUnits: number;
+    candidatesTouched: number;
+    readyCount: number;
+    lookbackHours: number;
+    callsRequired: number;
+    suggestions: UnitAliasSuggestion[];
+    message?: string;
+}
+
 export interface Site {
     id?: number | null;
     label?: string;
@@ -2246,6 +2285,41 @@ export class RdioScannerAdminService implements OnDestroy {
         return this.ngHttpClient.post<ToneHistoryAnalyzeResponse>(
             '/api/admin/tone-history-analyze',
             { systemId, talkgroupId, limit, hours },
+            { headers: this.getHeaders() },
+        ).pipe(timeout(900000));
+    }
+
+    getUnitAliasSuggestions(systemId: number, readyOnly = false): Observable<UnitAliasSuggestionsResponse> {
+        const params: Record<string, string | number | boolean> = { systemId };
+        if (readyOnly) {
+            params['ready'] = 1;
+        }
+        return this.ngHttpClient.get<UnitAliasSuggestionsResponse>(
+            '/api/admin/unit-alias-suggestions',
+            { headers: this.getHeaders(), params },
+        );
+    }
+
+    acceptUnitAliasSuggestion(candidateId: number, systemId: number, label?: string): Observable<void> {
+        return this.ngHttpClient.post<void>(
+            `/api/admin/unit-alias-suggestions/${candidateId}/accept`,
+            { label: label || '' },
+            { headers: this.getHeaders(), params: { systemId } },
+        );
+    }
+
+    dismissUnitAliasSuggestion(candidateId: number, systemId: number): Observable<void> {
+        return this.ngHttpClient.post<void>(
+            `/api/admin/unit-alias-suggestions/${candidateId}/dismiss`,
+            {},
+            { headers: this.getHeaders(), params: { systemId } },
+        );
+    }
+
+    scanUnitAliasHistory(systemId: number, hours = 168, limit = 200): Observable<UnitAliasScanResponse> {
+        return this.ngHttpClient.post<UnitAliasScanResponse>(
+            '/api/admin/unit-alias-history-scan',
+            { systemId, hours, limit },
             { headers: this.getHeaders() },
         ).pipe(timeout(900000));
     }

--- a/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.html
@@ -171,13 +171,15 @@
                 <label class="field-label">Auto-learn unit aliases</label>
                 <mat-slide-toggle color="primary" formControlName="autoLearnUnitAliases"></mat-slide-toggle>
             </div>
+            <span class="field-hint">Learns radio unit IDs → labels for the Source column. Consistent P25 aliases auto-add; OpenAI / ambiguous cases appear under Units for Accept / Dismiss. Requires alerts on the system and channel.</span>
             <ng-container *ngIf="form.get('autoLearnUnitAliases')?.value">
-                <mat-form-field appearance="outline" class="compact-field compact-field--no-hint" style="width: 100%;">
-                    <mat-label>Tags to enable</mat-label>
+                <mat-form-field appearance="outline" class="compact-field compact-field--no-hint" style="width: 100%; margin-top: 8px;">
+                    <mat-label>Limit to talkgroup tags (optional)</mat-label>
                     <mat-select formControlName="autoLearnUnitAliasesTagIds" multiple>
                         <mat-option *ngFor="let tag of tagsUsedInSystemList" [value]="tag.id">{{ tag.label }}</mat-option>
                     </mat-select>
                 </mat-form-field>
+                <span class="field-hint">Leave empty to enable on all talkgroups. Selecting tags only turns learning on for channels with those tags — it does not tag units.</span>
                 <mat-form-field appearance="outline" class="compact-field compact-field--no-hint" style="width: 220px; margin-top: 8px;">
                     <mat-label>Auto-off after (days)</mat-label>
                     <input type="number" min="0" step="1" matInput formControlName="autoLearnUnitAliasesAutoOffDays" placeholder="0 = never">
@@ -711,6 +713,74 @@
         <button type="button" mat-raised-button color="primary" (click)="addUnit()">
             <mat-icon>add</mat-icon> Add Unit
         </button>
+    </div>
+
+    <div class="unit-alias-learn-panel">
+        <div class="unit-alias-learn-header">
+            <div>
+                <div class="unit-alias-learn-title">Unit alias suggestions</div>
+                <div class="mat-caption">Radio IDs heard on channels with auto-learn. Consistent P25 aliases auto-add; otherwise review and Accept / Dismiss. Accepted labels appear in Source on transmissions.</div>
+            </div>
+            <div class="unit-alias-learn-actions">
+                <button type="button" mat-stroked-button color="primary"
+                        (click)="scanUnitAliasHistory()"
+                        [disabled]="scanningUnitAliases || !resolveUnitAliasSystemId()">
+                    <mat-icon>{{ scanningUnitAliases ? 'hourglass_empty' : 'manage_search' }}</mat-icon>
+                    {{ scanningUnitAliases ? 'Scanning…' : 'Scan recent history' }}
+                </button>
+                <button type="button" mat-stroked-button
+                        (click)="loadUnitAliasSuggestions()"
+                        [disabled]="loadingUnitAliasSuggestions || !resolveUnitAliasSystemId()">
+                    <mat-icon>refresh</mat-icon>
+                    Refresh
+                </button>
+            </div>
+        </div>
+        <div class="mat-caption unit-alias-status" *ngIf="unitAliasStatus as st">
+            <ng-container *ngIf="st.enabled; else unitLearnOff">
+                Learning on · ready after {{ st.callsRequired }} sightings ·
+                {{ st.pendingReady }} ready · {{ st.pendingAll }} pending
+            </ng-container>
+            <ng-template #unitLearnOff>Learning off for this system — enable Auto-learn unit aliases (or per talkgroup) to collect suggestions.</ng-template>
+        </div>
+        <div class="mat-caption" *ngIf="unitAliasScanMessage">{{ unitAliasScanMessage }}</div>
+
+        <div class="unit-alias-block" *ngIf="readyUnitAliasSuggestions.length">
+            <div class="unit-alias-section-label">Ready to review</div>
+            <div class="unit-alias-row" *ngFor="let s of readyUnitAliasSuggestions">
+                <div class="unit-alias-meta">
+                    <code class="id-code">{{ s.unitRef }}</code>
+                    <mat-form-field appearance="outline" class="unit-alias-label-field">
+                        <mat-label>Label</mat-label>
+                        <input matInput [(ngModel)]="unitAliasEditLabels[s.candidateId]" [ngModelOptions]="{standalone: true}" autocomplete="off">
+                    </mat-form-field>
+                    <span class="mat-caption">{{ s.sightings }} sightings<span *ngIf="s.usedOpenAI"> · OpenAI</span><span *ngIf="s.reason"> · {{ s.reason }}</span></span>
+                    <span class="mat-caption unit-alias-sample" *ngIf="s.sampleTranscript">{{ s.sampleTranscript }}</span>
+                </div>
+                <div class="unit-alias-btns">
+                    <button type="button" mat-flat-button color="primary" (click)="acceptUnitAliasSuggestion(s)">Accept</button>
+                    <button type="button" mat-stroked-button (click)="dismissUnitAliasSuggestion(s)">Dismiss</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="unit-alias-block unit-alias-emerging" *ngIf="emergingUnitAliasSuggestions.length">
+            <div class="unit-alias-section-label">Emerging</div>
+            <div class="unit-alias-row" *ngFor="let s of emergingUnitAliasSuggestions">
+                <div class="unit-alias-meta">
+                    <code class="id-code">{{ s.unitRef }}</code>
+                    <span class="mat-body">{{ s.suggestedLabel || 'Collecting…' }}</span>
+                    <span class="mat-caption">{{ s.sightings }} / {{ unitAliasStatus?.callsRequired || 3 }} sightings</span>
+                </div>
+                <div class="unit-alias-btns">
+                    <button type="button" mat-stroked-button (click)="dismissUnitAliasSuggestion(s)">Dismiss</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="mat-caption" *ngIf="!loadingUnitAliasSuggestions && !unitAliasSuggestions.length && resolveUnitAliasSystemId()">
+            No pending suggestions.
+        </div>
     </div>
 
     <div *ngIf="rawUnits.length === 0" class="sub-empty">

--- a/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.scss
@@ -550,6 +550,95 @@
     }
 }
 
+// ─── Unit alias suggestions ───────────────────────────────────────────────────
+.unit-alias-learn-panel {
+    margin: 0 0 16px;
+    padding: 12px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.unit-alias-learn-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 8px;
+}
+
+.unit-alias-learn-title {
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.unit-alias-learn-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.unit-alias-status {
+    margin-bottom: 8px;
+    opacity: 0.85;
+}
+
+.unit-alias-block {
+    margin-top: 12px;
+}
+
+.unit-alias-section-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.7;
+    margin-bottom: 6px;
+}
+
+.unit-alias-emerging {
+    opacity: 0.85;
+}
+
+.unit-alias-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 10px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.unit-alias-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+    flex: 1 1 240px;
+}
+
+.unit-alias-label-field {
+    width: min(320px, 100%);
+    margin-top: 4px;
+}
+
+.unit-alias-sample {
+    display: block;
+    opacity: 0.7;
+    max-width: 520px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.unit-alias-btns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
 // ─── Responsive ───────────────────────────────────────────────────────────────
 @media (max-width: 720px) {
     .settings-grid {

--- a/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.ts
@@ -24,7 +24,7 @@ import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
-import { RdioScannerAdminService, Group, Tag } from '../../../admin.service';
+import { RdioScannerAdminService, Group, Tag, UnitAliasSuggestion, UnitAliasLearnStatus } from '../../../admin.service';
 import { ToneSetLocationDialogComponent } from './tone-set-location-dialog.component';
 import { TalkgroupLocationDialogComponent } from './talkgroup-location-dialog.component';
 import { DeleteSystemDialogComponent } from '../delete-system-dialog.component';
@@ -80,6 +80,15 @@ export class RdioScannerAdminSystemComponent implements OnInit, OnChanges, OnDes
     // ─── Search ────────────────────────────────────────────────────────────────
     talkgroupsSearchTerm = '';
     unitsSearchTerm = '';
+
+    // ─── Unit alias suggestions ────────────────────────────────────────────────
+    unitAliasStatus: UnitAliasLearnStatus | null = null;
+    unitAliasSuggestions: UnitAliasSuggestion[] = [];
+    unitAliasEditLabels: Record<number, string> = {};
+    loadingUnitAliasSuggestions = false;
+    scanningUnitAliases = false;
+    unitAliasScanMessage = '';
+    private unitAliasSystemId = 0;
     sitesSearchTerm = '';
 
     // ─── Cached sorted arrays ──────────────────────────────────────────────────
@@ -137,6 +146,7 @@ export class RdioScannerAdminSystemComponent implements OnInit, OnChanges, OnDes
             this.expandedUnitFormSub = null;
             this.expandedRawUnit = null;
             this.expandedUnitForm = null;
+            this.loadUnitAliasSuggestions();
         }
 
         if (changes['form'] && !changes['form'].firstChange) {
@@ -156,6 +166,7 @@ export class RdioScannerAdminSystemComponent implements OnInit, OnChanges, OnDes
         this.rebuildLabelMaps();
         // Initialize raw units instantly from systemData — no FormGroups needed for display
         this.rawUnits = this.systemData?.units ? [...this.systemData.units] : [];
+        this.loadUnitAliasSuggestions();
 
         // Talkgroups still use progressive FormArray loading
         const tgArray = this.form.get('talkgroups') as FormArray | null;
@@ -528,6 +539,130 @@ export class RdioScannerAdminSystemComponent implements OnInit, OnChanges, OnDes
         if (!expiresAt || !this.form.get('autoLearnUnitAliases')?.value) return '';
         const d = new Date(expiresAt);
         return `Scheduled auto-off: ${d.toLocaleString()}`;
+    }
+
+    get readyUnitAliasSuggestions(): UnitAliasSuggestion[] {
+        return this.unitAliasSuggestions.filter(s => s.ready);
+    }
+
+    get emergingUnitAliasSuggestions(): UnitAliasSuggestion[] {
+        return this.unitAliasSuggestions.filter(s => !s.ready);
+    }
+
+    resolveUnitAliasSystemId(): number {
+        return this.systemId
+            || this.systemData?.id
+            || this.systemData?.systemId
+            || this.unitAliasSystemId
+            || 0;
+    }
+
+    loadUnitAliasSuggestions(): void {
+        const systemId = this.resolveUnitAliasSystemId();
+        if (!systemId) {
+            this.unitAliasSuggestions = [];
+            this.unitAliasStatus = null;
+            this.cdr.markForCheck();
+            return;
+        }
+        this.unitAliasSystemId = systemId;
+        this.loadingUnitAliasSuggestions = true;
+        this.cdr.markForCheck();
+        this.adminService.getUnitAliasSuggestions(systemId).subscribe({
+            next: (res) => {
+                this.unitAliasStatus = res?.status || null;
+                this.unitAliasSuggestions = res?.suggestions || [];
+                for (const s of this.unitAliasSuggestions) {
+                    if (this.unitAliasEditLabels[s.candidateId] === undefined) {
+                        this.unitAliasEditLabels[s.candidateId] = s.suggestedLabel || '';
+                    }
+                }
+                this.loadingUnitAliasSuggestions = false;
+                this.cdr.markForCheck();
+            },
+            error: () => {
+                this.loadingUnitAliasSuggestions = false;
+                this.cdr.markForCheck();
+            },
+        });
+    }
+
+    scanUnitAliasHistory(): void {
+        const systemId = this.resolveUnitAliasSystemId();
+        if (!systemId || this.scanningUnitAliases) return;
+        this.scanningUnitAliases = true;
+        this.unitAliasScanMessage = '';
+        this.cdr.markForCheck();
+        this.adminService.scanUnitAliasHistory(systemId).subscribe({
+            next: (res) => {
+                this.unitAliasSuggestions = res?.suggestions || [];
+                this.unitAliasScanMessage = res?.message || '';
+                this.unitAliasStatus = {
+                    enabled: this.unitAliasStatus?.enabled ?? true,
+                    callsRequired: res?.callsRequired || this.unitAliasStatus?.callsRequired || 3,
+                    pendingReady: res?.readyCount || 0,
+                    pendingAll: this.unitAliasSuggestions.length,
+                };
+                for (const s of this.unitAliasSuggestions) {
+                    this.unitAliasEditLabels[s.candidateId] = s.suggestedLabel || this.unitAliasEditLabels[s.candidateId] || '';
+                }
+                this.scanningUnitAliases = false;
+                this.snackBar.open(this.unitAliasScanMessage || 'Unit history scan complete.', 'OK', { duration: 5000 });
+                this.cdr.markForCheck();
+            },
+            error: (err) => {
+                this.scanningUnitAliases = false;
+                const msg = err?.error?.error || err?.message || 'Unit history scan failed';
+                this.snackBar.open(msg, 'OK', { duration: 6000 });
+                this.cdr.markForCheck();
+            },
+        });
+    }
+
+    acceptUnitAliasSuggestion(s: UnitAliasSuggestion): void {
+        const systemId = this.resolveUnitAliasSystemId();
+        if (!systemId) return;
+        const label = (this.unitAliasEditLabels[s.candidateId] ?? s.suggestedLabel ?? '').trim();
+        if (!label) {
+            this.snackBar.open('Enter a label before accepting.', 'OK', { duration: 4000 });
+            return;
+        }
+        this.adminService.acceptUnitAliasSuggestion(s.candidateId, systemId, label).subscribe({
+            next: () => {
+                const existing = this.rawUnits.find(u => Number(u.unitRef) === Number(s.unitRef));
+                if (existing) {
+                    existing.label = label;
+                } else {
+                    this.rawUnits = [
+                        { id: null, label, order: 0, unitRef: s.unitRef, unitFrom: null, unitTo: null },
+                        ...this.rawUnits,
+                    ];
+                }
+                if (this.systemData) this.systemData.units = this.rawUnits;
+                this.form.markAsDirty();
+                this.snackBar.open(`Added unit ${label} (ID ${s.unitRef}) for Source.`, 'OK', { duration: 4000 });
+                this.loadUnitAliasSuggestions();
+                this.cdr.markForCheck();
+            },
+            error: (err) => {
+                const msg = err?.error?.error || err?.message || 'Accept failed';
+                this.snackBar.open(msg, 'OK', { duration: 6000 });
+            },
+        });
+    }
+
+    dismissUnitAliasSuggestion(s: UnitAliasSuggestion): void {
+        const systemId = this.resolveUnitAliasSystemId();
+        if (!systemId) return;
+        this.adminService.dismissUnitAliasSuggestion(s.candidateId, systemId).subscribe({
+            next: () => {
+                this.loadUnitAliasSuggestions();
+            },
+            error: (err) => {
+                const msg = err?.error?.error || err?.message || 'Dismiss failed';
+                this.snackBar.open(msg, 'OK', { duration: 6000 });
+            },
+        });
     }
 
     // ─── Bulk selection ────────────────────────────────────────────────────────

--- a/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/talkgroup/talkgroup.component.html
@@ -300,7 +300,7 @@
     <div class="row">
         <p>
             <span class="mat-body">Auto-learn unit aliases</span><br>
-            <span class="mat-caption">Observe radio unit IDs on this channel. Consistent P25 aliases auto-add; otherwise OpenAI suggests a label from voice. Can be enabled per talkgroup here, or in bulk via system tag rollout.</span>
+            <span class="mat-caption">Observe radio unit IDs on this channel. Consistent P25 aliases auto-add; otherwise suggestions appear under the system Units panel for Accept / Dismiss. Can also be enabled in bulk via the system Auto-learn unit aliases toggle (all channels, or limited by talkgroup tag).</span>
         </p>
         <div>
             <mat-slide-toggle color="primary" formControlName="autoLearnUnitAliases"></mat-slide-toggle>

--- a/server/database.go
+++ b/server/database.go
@@ -396,6 +396,7 @@ func (db *Database) migrate() error {
 		{"migrateBulkToneDetection", migrateBulkToneDetection},
 		{"migrateUnitAliasAutoLearn", migrateUnitAliasAutoLearn},
 		{"migrateAutoLearnTagRollout", migrateAutoLearnTagRollout},
+		{"migrateUnitAliasSuggestionsReview", migrateUnitAliasSuggestionsReview},
 		{"migrateCallsVerifiedDuplicate", migrateCallsVerifiedDuplicate},
 		{"migratePostgresSiteRefToText", migratePostgresSiteRefToText},
 		{"migrateApikeyNoAudioMonitoring", migrateApikeyNoAudioMonitoring},

--- a/server/main.go
+++ b/server/main.go
@@ -378,6 +378,9 @@ func main() {
 	http.HandleFunc("/api/admin/tone-import", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.ToneImportHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/sync-tone-sets", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.SyncToneSetsHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/tone-history-analyze", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.ToneHistoryAnalyzeHandler)).ServeHTTP)
+	http.HandleFunc("/api/admin/unit-alias-suggestions", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.UnitAliasSuggestionsHandler)).ServeHTTP)
+	http.HandleFunc("/api/admin/unit-alias-suggestions/", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.UnitAliasSuggestionActionHandler)).ServeHTTP)
+	http.HandleFunc("/api/admin/unit-alias-history-scan", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.UnitAliasHistoryScanHandler)).ServeHTTP)
 
 	http.HandleFunc("/api/admin/config", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.ConfigHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/options", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.OptionsPatchHandler)).ServeHTTP)

--- a/server/migrations.go
+++ b/server/migrations.go
@@ -2914,6 +2914,24 @@ func migrateUnitAliasAutoLearn(db *Database) error {
 	return nil
 }
 
+// migrateUnitAliasSuggestionsReview adds Accept/Dismiss review columns for unit alias learning.
+func migrateUnitAliasSuggestionsReview(db *Database) error {
+	queries := []string{
+		`ALTER TABLE "unitAliasLearnCandidates" ADD COLUMN IF NOT EXISTS "suggestedLabel" text NOT NULL DEFAULT ''`,
+		`ALTER TABLE "unitAliasLearnCandidates" ADD COLUMN IF NOT EXISTS "reason" text NOT NULL DEFAULT ''`,
+		`ALTER TABLE "unitAliasLearnCandidates" ADD COLUMN IF NOT EXISTS "usedOpenAI" boolean NOT NULL DEFAULT false`,
+		`ALTER TABLE "unitAliasLearnCandidates" ADD COLUMN IF NOT EXISTS "acceptedAt" bigint NOT NULL DEFAULT 0`,
+		`ALTER TABLE "unitAliasLearnCandidates" ADD COLUMN IF NOT EXISTS "dismissedAt" bigint NOT NULL DEFAULT 0`,
+		`CREATE INDEX IF NOT EXISTS "unitAliasLearnCandidates_review_idx" ON "unitAliasLearnCandidates" ("systemId", "dismissedAt", "acceptedAt", "finalizedAt", "lastSeenAt" DESC)`,
+	}
+	for _, q := range queries {
+		if _, err := db.Sql.Exec(q); err != nil {
+			log.Printf("migrateUnitAliasSuggestionsReview note: %v", err)
+		}
+	}
+	return nil
+}
+
 // migrateAutoLearnTagRollout adds tag-based rollout for tone and unit alias auto-learn.
 func migrateAutoLearnTagRollout(db *Database) error {
 	queries := []string{

--- a/server/system_auto_learn_rollout.go
+++ b/server/system_auto_learn_rollout.go
@@ -34,18 +34,14 @@ func (system *System) applyAutoLearnToneSetsRollout() {
 	}
 }
 
-// applyAutoLearnUnitAliasesRollout enables unit alias auto-learn on talkgroups matching selected tags.
+// applyAutoLearnUnitAliasesRollout enables unit alias auto-learn on talkgroups.
+// Empty tag list = all talkgroups in the system; selected tags restrict to matching channels.
 func (system *System) applyAutoLearnUnitAliasesRollout() {
 	if system == nil {
 		return
 	}
 
 	if system.Talkgroups == nil {
-		return
-	}
-
-	tagSet := bulkToneTagSet(system.AutoLearnUnitAliasesTagIds)
-	if len(tagSet) == 0 {
 		return
 	}
 
@@ -58,8 +54,10 @@ func (system *System) applyAutoLearnUnitAliasesRollout() {
 	if system.AutoLearnUnitAliasesAutoOffDays > 0 && system.AutoLearnUnitAliasesExpiresAt == 0 {
 		system.AutoLearnUnitAliasesExpiresAt = now + int64(system.AutoLearnUnitAliasesAutoOffDays)*24*60*60*1000
 	}
+
+	tagSet := bulkToneTagSet(system.AutoLearnUnitAliasesTagIds)
 	for _, tg := range system.Talkgroups.List {
-		if tagSet[tg.TagId] {
+		if len(tagSet) == 0 || tagSet[tg.TagId] {
 			tg.AutoLearnUnitAliases = true
 		}
 	}

--- a/server/system_unit_learn.go
+++ b/server/system_unit_learn.go
@@ -32,23 +32,33 @@ func (controller *Controller) expireAutoLearnUnitAliases() {
 
 func (controller *Controller) finalizeAutoLearnUnitAliasesExpiry(system *System) {
 	tagSet := bulkToneTagSet(system.AutoLearnUnitAliasesTagIds)
-	if len(tagSet) == 0 {
-		return
-	}
-
 	disabled := 0
-	for tagId := range tagSet {
-		q := `UPDATE "talkgroups" SET "autoLearnUnitAliases" = false WHERE "systemId" = ? AND "tagId" = ?`
+
+	if len(tagSet) == 0 {
+		q := `UPDATE "talkgroups" SET "autoLearnUnitAliases" = false WHERE "systemId" = ?`
 		if controller.Database.Config.DbType == DbTypePostgresql {
-			q = `UPDATE "talkgroups" SET "autoLearnUnitAliases" = false WHERE "systemId" = $1 AND "tagId" = $2`
+			q = `UPDATE "talkgroups" SET "autoLearnUnitAliases" = false WHERE "systemId" = $1`
 		}
-		res, err := controller.Database.Sql.Exec(q, system.Id, tagId)
+		res, err := controller.Database.Sql.Exec(q, system.Id)
 		if err != nil {
-			controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit auto-learn expiry: disable tag %d on system %d failed: %v", tagId, system.Id, err))
-			continue
+			controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit auto-learn expiry: disable all talkgroups on system %d failed: %v", system.Id, err))
+		} else if n, _ := res.RowsAffected(); n > 0 {
+			disabled = int(n)
 		}
-		if n, _ := res.RowsAffected(); n > 0 {
-			disabled += int(n)
+	} else {
+		for tagId := range tagSet {
+			q := `UPDATE "talkgroups" SET "autoLearnUnitAliases" = false WHERE "systemId" = ? AND "tagId" = ?`
+			if controller.Database.Config.DbType == DbTypePostgresql {
+				q = `UPDATE "talkgroups" SET "autoLearnUnitAliases" = false WHERE "systemId" = $1 AND "tagId" = $2`
+			}
+			res, err := controller.Database.Sql.Exec(q, system.Id, tagId)
+			if err != nil {
+				controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit auto-learn expiry: disable tag %d on system %d failed: %v", tagId, system.Id, err))
+				continue
+			}
+			if n, _ := res.RowsAffected(); n > 0 {
+				disabled += int(n)
+			}
 		}
 	}
 
@@ -69,7 +79,7 @@ func (controller *Controller) finalizeAutoLearnUnitAliasesExpiry(system *System)
 		sys.AutoLearnUnitAliasesExpiresAt = 0
 		if sys.Talkgroups != nil {
 			for _, tg := range sys.Talkgroups.List {
-				if tagSet[tg.TagId] {
+				if len(tagSet) == 0 || tagSet[tg.TagId] {
 					tg.AutoLearnUnitAliases = false
 				}
 			}

--- a/server/unit_learn.go
+++ b/server/unit_learn.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Thinline Dynamic Solutions
 //
 // Auto-learn unit aliases: map radio unitRef to human labels using metadata and OpenAI.
+// Consistent P25 radio aliases auto-add; OpenAI / conflicts queue for admin Accept/Dismiss.
 
 package main
 
@@ -12,11 +13,13 @@ import (
 	"time"
 )
 
+const unitLearnMaxCallRecords = 25
+
 type unitLearnCallRecord struct {
-	CallId      uint64 `json:"callId"`
-	Transcript  string `json:"transcript"`
-	RadioLabel  string `json:"radioLabel"`
-	Timestamp   int64  `json:"timestamp"`
+	CallId     uint64 `json:"callId"`
+	Transcript string `json:"transcript"`
+	RadioLabel string `json:"radioLabel"`
+	Timestamp  int64  `json:"timestamp"`
 }
 
 type unitObservation struct {
@@ -99,7 +102,16 @@ func unitExistsWithLabel(units *Units, unitRef uint) bool {
 	return false
 }
 
-// processUnitAutoLearn records unitRef observations and auto-adds aliases after N calls.
+func truncateUnitLearnTranscript(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 240 {
+		return s[:240]
+	}
+	return s
+}
+
+// processUnitAutoLearn records unitRef observations and auto-adds confident P25 aliases
+// after N calls; OpenAI / ambiguous cases become reviewable suggestions.
 func (controller *Controller) processUnitAutoLearn(call *Call, transcript string) {
 	if controller == nil || call == nil || !unitLearnEnabled(call) {
 		return
@@ -127,32 +139,35 @@ func (controller *Controller) upsertUnitLearnCandidate(call *Call, obs unitObser
 
 	var candidateId uint64
 	var callRecordsJson string
-	var finalizedAt sql.NullInt64
+	var finalizedAt, acceptedAt, dismissedAt sql.NullInt64
 
-	selectQuery := `SELECT "candidateId", "callRecords", "finalizedAt" FROM "unitAliasLearnCandidates" WHERE "systemId" = $1 AND "talkgroupId" = $2 AND "unitRef" = $3`
+	selectQuery := `SELECT "candidateId", "callRecords", "finalizedAt", "acceptedAt", "dismissedAt" FROM "unitAliasLearnCandidates" WHERE "systemId" = $1 AND "talkgroupId" = $2 AND "unitRef" = $3`
 	if controller.Database.Config.DbType != DbTypePostgresql {
-		selectQuery = `SELECT "candidateId", "callRecords", "finalizedAt" FROM "unitAliasLearnCandidates" WHERE "systemId" = ? AND "talkgroupId" = ? AND "unitRef" = ?`
+		selectQuery = `SELECT "candidateId", "callRecords", "finalizedAt", "acceptedAt", "dismissedAt" FROM "unitAliasLearnCandidates" WHERE "systemId" = ? AND "talkgroupId" = ? AND "unitRef" = ?`
 	}
 
 	err := controller.Database.Sql.QueryRow(selectQuery, call.System.Id, call.Talkgroup.Id, obs.UnitRef).
-		Scan(&candidateId, &callRecordsJson, &finalizedAt)
+		Scan(&candidateId, &callRecordsJson, &finalizedAt, &acceptedAt, &dismissedAt)
 
 	records := []unitLearnCallRecord{}
 	if err == nil && callRecordsJson != "" {
 		_ = json.Unmarshal([]byte(callRecordsJson), &records)
 	}
 
-	if finalizedAt.Valid && finalizedAt.Int64 > 0 {
+	if (finalizedAt.Valid && finalizedAt.Int64 > 0) ||
+		(acceptedAt.Valid && acceptedAt.Int64 > 0) ||
+		(dismissedAt.Valid && dismissedAt.Int64 > 0) {
 		return
 	}
 
+	snippet := truncateUnitLearnTranscript(transcript)
 	updatedExisting := false
 	for i, r := range records {
 		if r.CallId != call.Id {
 			continue
 		}
-		if transcript != "" {
-			records[i].Transcript = transcript
+		if snippet != "" {
+			records[i].Transcript = snippet
 		}
 		if strings.TrimSpace(obs.RadioLabel) != "" {
 			records[i].RadioLabel = strings.TrimSpace(obs.RadioLabel)
@@ -164,10 +179,13 @@ func (controller *Controller) upsertUnitLearnCandidate(call *Call, obs unitObser
 	if !updatedExisting {
 		records = append(records, unitLearnCallRecord{
 			CallId:     call.Id,
-			Transcript: transcript,
+			Transcript: snippet,
 			RadioLabel: strings.TrimSpace(obs.RadioLabel),
 			Timestamp:  call.Timestamp.UnixMilli(),
 		})
+	}
+	if len(records) > unitLearnMaxCallRecords {
+		records = records[len(records)-unitLearnMaxCallRecords:]
 	}
 	recordsJson, _ := json.Marshal(records)
 
@@ -203,8 +221,8 @@ func (controller *Controller) upsertUnitLearnCandidate(call *Call, obs unitObser
 
 	label, consistent, conflict := consistentRadioLabel(records)
 	if conflict {
-		controller.skipUnitLearnCandidate(call.System, call.Talkgroup, obs.UnitRef,
-			"conflicting radio aliases across calls")
+		controller.queueUnitLearnForReview(call.System, call.Talkgroup, obs.UnitRef, "",
+			"conflicting radio aliases across calls", false)
 		return
 	}
 	if consistent && label != "" {
@@ -222,27 +240,30 @@ func (controller *Controller) upsertUnitLearnCandidate(call *Call, obs unitObser
 
 	suggested := controller.suggestUnitLearnLabel(call.System, call.Talkgroup, obs.UnitRef, records)
 	if suggested == "" || suggested == "UNKNOWN" {
-		controller.skipUnitLearnCandidate(call.System, call.Talkgroup, obs.UnitRef,
-			"could not determine a consistent unit label")
+		controller.queueUnitLearnForReview(call.System, call.Talkgroup, obs.UnitRef, "",
+			"could not determine a consistent unit label", true)
 		return
 	}
-	go controller.autoAddLearnedUnitAlias(call.System, call.Talkgroup, obs.UnitRef, suggested, records, true)
+	controller.queueUnitLearnForReview(call.System, call.Talkgroup, obs.UnitRef, suggested,
+		"suggested from voice transcripts", true)
 }
 
-// skipUnitLearnCandidate marks a candidate finalized without auto-adding or emailing.
-func (controller *Controller) skipUnitLearnCandidate(system *System, talkgroup *Talkgroup, unitRef uint, reason string) {
+// queueUnitLearnForReview stores a suggested label for admin Accept/Dismiss (does not write units).
+func (controller *Controller) queueUnitLearnForReview(system *System, talkgroup *Talkgroup, unitRef uint, suggestedLabel, reason string, usedOpenAI bool) {
 	if controller == nil || system == nil || talkgroup == nil || unitRef == 0 {
 		return
 	}
 
-	now := time.Now().UnixMilli()
-	updateQuery := `UPDATE "unitAliasLearnCandidates" SET "finalizedAt" = $1 WHERE "systemId" = $2 AND "talkgroupId" = $3 AND "unitRef" = $4 AND ("finalizedAt" IS NULL OR "finalizedAt" = 0)`
+	suggestedLabel = strings.TrimSpace(suggestedLabel)
+	reason = strings.TrimSpace(reason)
+
+	updateQuery := `UPDATE "unitAliasLearnCandidates" SET "suggestedLabel" = $1, "reason" = $2, "usedOpenAI" = $3 WHERE "systemId" = $4 AND "talkgroupId" = $5 AND "unitRef" = $6 AND ("finalizedAt" IS NULL OR "finalizedAt" = 0) AND ("acceptedAt" IS NULL OR "acceptedAt" = 0) AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
 	if controller.Database.Config.DbType != DbTypePostgresql {
-		updateQuery = `UPDATE "unitAliasLearnCandidates" SET "finalizedAt" = ? WHERE "systemId" = ? AND "talkgroupId" = ? AND "unitRef" = ? AND ("finalizedAt" IS NULL OR "finalizedAt" = 0)`
+		updateQuery = `UPDATE "unitAliasLearnCandidates" SET "suggestedLabel" = ?, "reason" = ?, "usedOpenAI" = ? WHERE "systemId" = ? AND "talkgroupId" = ? AND "unitRef" = ? AND ("finalizedAt" IS NULL OR "finalizedAt" = 0) AND ("acceptedAt" IS NULL OR "acceptedAt" = 0) AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
 	}
-	res, err := controller.Database.Sql.Exec(updateQuery, now, system.Id, talkgroup.Id, unitRef)
+	res, err := controller.Database.Sql.Exec(updateQuery, suggestedLabel, reason, usedOpenAI, system.Id, talkgroup.Id, unitRef)
 	if err != nil {
-		controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit auto-learn: mark skipped failed: %v", err))
+		controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit auto-learn: queue for review failed: %v", err))
 		return
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
@@ -250,8 +271,8 @@ func (controller *Controller) skipUnitLearnCandidate(system *System, talkgroup *
 	}
 
 	controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf(
-		"unit auto-learn: skipped unitRef %d on talkgroup %d — %s (add manually in admin if needed)",
-		unitRef, talkgroup.TalkgroupRef, reason,
+		"unit auto-learn: queued unitRef %d on talkgroup %d for review — %s (label=%q)",
+		unitRef, talkgroup.TalkgroupRef, reason, suggestedLabel,
 	))
 }
 
@@ -302,11 +323,17 @@ func (controller *Controller) autoAddLearnedUnitAlias(system *System, talkgroup 
 	}
 
 	now := time.Now().UnixMilli()
-	updateQuery := `UPDATE "unitAliasLearnCandidates" SET "finalizedAt" = $1 WHERE "systemId" = $2 AND "talkgroupId" = $3 AND "unitRef" = $4 AND ("finalizedAt" IS NULL OR "finalizedAt" = 0)`
+	updateQuery := `UPDATE "unitAliasLearnCandidates" SET "finalizedAt" = $1, "acceptedAt" = $1, "suggestedLabel" = $2, "usedOpenAI" = $3 WHERE "systemId" = $4 AND "talkgroupId" = $5 AND "unitRef" = $6 AND ("finalizedAt" IS NULL OR "finalizedAt" = 0) AND ("acceptedAt" IS NULL OR "acceptedAt" = 0) AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
 	if controller.Database.Config.DbType != DbTypePostgresql {
-		updateQuery = `UPDATE "unitAliasLearnCandidates" SET "finalizedAt" = ? WHERE "systemId" = ? AND "talkgroupId" = ? AND "unitRef" = ? AND ("finalizedAt" IS NULL OR "finalizedAt" = 0)`
+		updateQuery = `UPDATE "unitAliasLearnCandidates" SET "finalizedAt" = ?, "acceptedAt" = ?, "suggestedLabel" = ?, "usedOpenAI" = ? WHERE "systemId" = ? AND "talkgroupId" = ? AND "unitRef" = ? AND ("finalizedAt" IS NULL OR "finalizedAt" = 0) AND ("acceptedAt" IS NULL OR "acceptedAt" = 0) AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
 	}
-	res, err := controller.Database.Sql.Exec(updateQuery, now, system.Id, talkgroup.Id, unitRef)
+	var res sql.Result
+	var err error
+	if controller.Database.Config.DbType == DbTypePostgresql {
+		res, err = controller.Database.Sql.Exec(updateQuery, now, label, usedOpenAI, system.Id, talkgroup.Id, unitRef)
+	} else {
+		res, err = controller.Database.Sql.Exec(updateQuery, now, now, label, usedOpenAI, system.Id, talkgroup.Id, unitRef)
+	}
 	if err != nil {
 		controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit auto-learn: mark finalized failed: %v", err))
 		return

--- a/server/unit_learn_review.go
+++ b/server/unit_learn_review.go
@@ -1,0 +1,677 @@
+// Copyright (C) 2025 Thinline Dynamic Solutions
+//
+// Admin review APIs for unit alias auto-learn suggestions (Accept / Dismiss / history scan).
+
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	unitAliasScanDefaultHours = 168
+	unitAliasScanMaxHours     = 720
+	unitAliasScanDefaultLimit = 200
+	unitAliasScanMaxLimit     = 500
+)
+
+// UnitAliasSuggestion is a rolled-up review row for one system unitRef.
+type UnitAliasSuggestion struct {
+	CandidateId    uint64   `json:"candidateId"`
+	SystemId       uint64   `json:"systemId"`
+	UnitRef        uint     `json:"unitRef"`
+	SuggestedLabel string   `json:"suggestedLabel"`
+	Reason         string   `json:"reason,omitempty"`
+	UsedOpenAI     bool     `json:"usedOpenAI"`
+	Sightings      int      `json:"sightings"`
+	SampleCallIds  []uint64 `json:"sampleCallIds,omitempty"`
+	SampleTranscript string `json:"sampleTranscript,omitempty"`
+	FirstSeenAt    int64    `json:"firstSeenAt"`
+	LastSeenAt     int64    `json:"lastSeenAt"`
+	Ready          bool     `json:"ready"`
+	TalkgroupIds   []uint64 `json:"talkgroupIds,omitempty"`
+}
+
+type UnitAliasLearnStatus struct {
+	Enabled       bool `json:"enabled"`
+	CallsRequired int  `json:"callsRequired"`
+	PendingReady  int  `json:"pendingReady"`
+	PendingAll    int  `json:"pendingAll"`
+}
+
+type UnitAliasSuggestionsResponse struct {
+	Status      UnitAliasLearnStatus   `json:"status"`
+	Suggestions []UnitAliasSuggestion  `json:"suggestions"`
+}
+
+type UnitAliasScanRequest struct {
+	SystemId uint64 `json:"systemId"`
+	Hours    int    `json:"hours"`
+	Limit    int    `json:"limit"`
+}
+
+type UnitAliasScanResponse struct {
+	CallsScanned      int                   `json:"callsScanned"`
+	CallsWithUnits    int                   `json:"callsWithUnits"`
+	CandidatesTouched int                   `json:"candidatesTouched"`
+	ReadyCount        int                   `json:"readyCount"`
+	LookbackHours     int                   `json:"lookbackHours"`
+	CallsRequired     int                   `json:"callsRequired"`
+	Suggestions       []UnitAliasSuggestion `json:"suggestions"`
+	Message           string                `json:"message,omitempty"`
+}
+
+type UnitAliasAcceptRequest struct {
+	Label string `json:"label"`
+}
+
+func (controller *Controller) unitLearnCallsRequired() int {
+	cfg := controller.Options.AutoLearnToneSetConfig
+	cfg.normalize()
+	return cfg.CallsRequired
+}
+
+func (controller *Controller) systemHasUnitLearnEnabled(systemId uint64) bool {
+	sys, ok := controller.Systems.GetSystemById(systemId)
+	if !ok || sys == nil {
+		return false
+	}
+	if sys.AutoLearnUnitAliases {
+		return true
+	}
+	if sys.Talkgroups == nil {
+		return false
+	}
+	for _, tg := range sys.Talkgroups.List {
+		if tg != nil && tg.AutoLearnUnitAliases {
+			return true
+		}
+	}
+	return false
+}
+
+func (controller *Controller) listUnitAliasSuggestions(systemId uint64, readyOnly bool) ([]UnitAliasSuggestion, error) {
+	if controller == nil || controller.Database == nil || controller.Database.Sql == nil {
+		return nil, fmt.Errorf("database unavailable")
+	}
+	if systemId == 0 {
+		return nil, fmt.Errorf("systemId is required")
+	}
+
+	callsRequired := controller.unitLearnCallsRequired()
+
+	query := `SELECT "candidateId", "systemId", "talkgroupId", "unitRef", "callRecords", "suggestedLabel", "reason", "usedOpenAI", "firstSeenAt", "lastSeenAt"
+		FROM "unitAliasLearnCandidates"
+		WHERE "systemId" = $1
+		  AND ("finalizedAt" IS NULL OR "finalizedAt" = 0)
+		  AND ("acceptedAt" IS NULL OR "acceptedAt" = 0)
+		  AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)
+		ORDER BY "lastSeenAt" DESC
+		LIMIT 500`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		query = `SELECT "candidateId", "systemId", "talkgroupId", "unitRef", "callRecords", "suggestedLabel", "reason", "usedOpenAI", "firstSeenAt", "lastSeenAt"
+			FROM "unitAliasLearnCandidates"
+			WHERE "systemId" = ?
+			  AND ("finalizedAt" IS NULL OR "finalizedAt" = 0)
+			  AND ("acceptedAt" IS NULL OR "acceptedAt" = 0)
+			  AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)
+			ORDER BY "lastSeenAt" DESC
+			LIMIT 500`
+	}
+
+	rows, err := controller.Database.Sql.Query(query, systemId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type rowData struct {
+		candidateId    uint64
+		talkgroupId    uint64
+		unitRef        uint
+		records        []unitLearnCallRecord
+		suggestedLabel string
+		reason         string
+		usedOpenAI     bool
+		firstSeenAt    int64
+		lastSeenAt     int64
+	}
+
+	byUnit := map[uint]*UnitAliasSuggestion{}
+	callSeen := map[uint]map[uint64]bool{}
+
+	for rows.Next() {
+		var (
+			r              rowData
+			recordsJSON    string
+			systemIdScan   uint64
+			usedOpenAIScan bool
+		)
+		if err := rows.Scan(&r.candidateId, &systemIdScan, &r.talkgroupId, &r.unitRef, &recordsJSON,
+			&r.suggestedLabel, &r.reason, &usedOpenAIScan, &r.firstSeenAt, &r.lastSeenAt); err != nil {
+			return nil, err
+		}
+		r.usedOpenAI = usedOpenAIScan
+		if recordsJSON != "" {
+			_ = json.Unmarshal([]byte(recordsJSON), &r.records)
+		}
+
+		s, ok := byUnit[r.unitRef]
+		if !ok {
+			s = &UnitAliasSuggestion{
+				CandidateId:    r.candidateId,
+				SystemId:       systemId,
+				UnitRef:        r.unitRef,
+				SuggestedLabel: strings.TrimSpace(r.suggestedLabel),
+				Reason:         strings.TrimSpace(r.reason),
+				UsedOpenAI:     r.usedOpenAI,
+				FirstSeenAt:    r.firstSeenAt,
+				LastSeenAt:     r.lastSeenAt,
+				TalkgroupIds:   []uint64{},
+				SampleCallIds:  []uint64{},
+			}
+			byUnit[r.unitRef] = s
+			callSeen[r.unitRef] = map[uint64]bool{}
+		}
+
+		s.TalkgroupIds = appendUniqueUint64(s.TalkgroupIds, r.talkgroupId)
+		if r.lastSeenAt > s.LastSeenAt {
+			s.LastSeenAt = r.lastSeenAt
+			s.CandidateId = r.candidateId
+		}
+		if r.firstSeenAt > 0 && (s.FirstSeenAt == 0 || r.firstSeenAt < s.FirstSeenAt) {
+			s.FirstSeenAt = r.firstSeenAt
+		}
+		if strings.TrimSpace(r.suggestedLabel) != "" && (s.SuggestedLabel == "" || r.usedOpenAI) {
+			s.SuggestedLabel = strings.TrimSpace(r.suggestedLabel)
+			s.UsedOpenAI = r.usedOpenAI
+		}
+		if strings.TrimSpace(r.reason) != "" && s.Reason == "" {
+			s.Reason = strings.TrimSpace(r.reason)
+		}
+
+		for _, rec := range r.records {
+			if rec.CallId == 0 || callSeen[r.unitRef][rec.CallId] {
+				continue
+			}
+			callSeen[r.unitRef][rec.CallId] = true
+			s.Sightings++
+			if len(s.SampleCallIds) < 8 {
+				s.SampleCallIds = append(s.SampleCallIds, rec.CallId)
+			}
+			if s.SampleTranscript == "" && strings.TrimSpace(rec.Transcript) != "" {
+				s.SampleTranscript = truncateUnitLearnTranscript(rec.Transcript)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]UnitAliasSuggestion, 0, len(byUnit))
+	for _, s := range byUnit {
+		s.Ready = s.Sightings >= callsRequired && (strings.TrimSpace(s.SuggestedLabel) != "" || strings.TrimSpace(s.Reason) != "")
+		if readyOnly && !s.Ready {
+			continue
+		}
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Ready != out[j].Ready {
+			return out[i].Ready
+		}
+		return out[i].LastSeenAt > out[j].LastSeenAt
+	})
+	return out, nil
+}
+
+func appendUniqueUint64(list []uint64, v uint64) []uint64 {
+	for _, x := range list {
+		if x == v {
+			return list
+		}
+	}
+	return append(list, v)
+}
+
+func (controller *Controller) acceptUnitAliasSuggestion(systemId, candidateId uint64, labelOverride string) error {
+	if controller == nil || controller.Database == nil {
+		return fmt.Errorf("database unavailable")
+	}
+
+	var (
+		unitRef        uint
+		suggestedLabel string
+		sysId          uint64
+		usedOpenAI     bool
+		finalizedAt    int64
+		acceptedAt     int64
+		dismissedAt    int64
+	)
+
+	sel := `SELECT "systemId", "unitRef", "suggestedLabel", "usedOpenAI", "finalizedAt", "acceptedAt", "dismissedAt"
+		FROM "unitAliasLearnCandidates" WHERE "candidateId" = $1`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		sel = `SELECT "systemId", "unitRef", "suggestedLabel", "usedOpenAI", "finalizedAt", "acceptedAt", "dismissedAt"
+			FROM "unitAliasLearnCandidates" WHERE "candidateId" = ?`
+	}
+	err := controller.Database.Sql.QueryRow(sel, candidateId).
+		Scan(&sysId, &unitRef, &suggestedLabel, &usedOpenAI, &finalizedAt, &acceptedAt, &dismissedAt)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("suggestion not found")
+	}
+	if err != nil {
+		return err
+	}
+	if systemId != 0 && sysId != systemId {
+		return fmt.Errorf("suggestion does not belong to this system")
+	}
+	if dismissedAt > 0 {
+		return fmt.Errorf("suggestion was dismissed")
+	}
+	if acceptedAt > 0 || finalizedAt > 0 {
+		return nil
+	}
+
+	label := strings.TrimSpace(labelOverride)
+	if label == "" {
+		label = strings.TrimSpace(suggestedLabel)
+	}
+	if label == "" {
+		return fmt.Errorf("label is required — enter a unit label to accept")
+	}
+
+	sys, ok := controller.Systems.GetSystemById(sysId)
+	if !ok {
+		return fmt.Errorf("system %d not found", sysId)
+	}
+
+	if !unitExistsWithLabel(sys.Units, unitRef) {
+		if err := controller.persistLearnedUnit(sys.Id, unitRef, label); err != nil {
+			return fmt.Errorf("persist unit: %w", err)
+		}
+		sys.Units.Add(unitRef, label)
+	}
+
+	now := time.Now().UnixMilli()
+	upd := `UPDATE "unitAliasLearnCandidates"
+		SET "acceptedAt" = $1, "finalizedAt" = $1, "suggestedLabel" = $2
+		WHERE "systemId" = $3 AND "unitRef" = $4
+		  AND ("acceptedAt" IS NULL OR "acceptedAt" = 0)
+		  AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		upd = `UPDATE "unitAliasLearnCandidates"
+			SET "acceptedAt" = ?, "finalizedAt" = ?, "suggestedLabel" = ?
+			WHERE "systemId" = ? AND "unitRef" = ?
+			  AND ("acceptedAt" IS NULL OR "acceptedAt" = 0)
+			  AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
+		_, err = controller.Database.Sql.Exec(upd, now, now, label, sysId, unitRef)
+	} else {
+		_, err = controller.Database.Sql.Exec(upd, now, label, sysId, unitRef)
+	}
+	if err != nil {
+		return err
+	}
+
+	controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf(
+		"unit auto-learn: accepted unit %q (ref %d) on system %s (openai=%v)",
+		label, unitRef, sys.Label, usedOpenAI,
+	))
+	return nil
+}
+
+func (controller *Controller) dismissUnitAliasSuggestion(systemId, candidateId uint64) error {
+	if controller == nil || controller.Database == nil {
+		return fmt.Errorf("database unavailable")
+	}
+
+	var (
+		unitRef     uint
+		sysId       uint64
+		acceptedAt  int64
+		dismissedAt int64
+	)
+	sel := `SELECT "systemId", "unitRef", "acceptedAt", "dismissedAt" FROM "unitAliasLearnCandidates" WHERE "candidateId" = $1`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		sel = `SELECT "systemId", "unitRef", "acceptedAt", "dismissedAt" FROM "unitAliasLearnCandidates" WHERE "candidateId" = ?`
+	}
+	err := controller.Database.Sql.QueryRow(sel, candidateId).Scan(&sysId, &unitRef, &acceptedAt, &dismissedAt)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("suggestion not found")
+	}
+	if err != nil {
+		return err
+	}
+	if systemId != 0 && sysId != systemId {
+		return fmt.Errorf("suggestion does not belong to this system")
+	}
+	if acceptedAt > 0 {
+		return fmt.Errorf("suggestion already accepted")
+	}
+	if dismissedAt > 0 {
+		return nil
+	}
+
+	now := time.Now().UnixMilli()
+	upd := `UPDATE "unitAliasLearnCandidates" SET "dismissedAt" = $1, "finalizedAt" = $1
+		WHERE "systemId" = $2 AND "unitRef" = $3
+		  AND ("acceptedAt" IS NULL OR "acceptedAt" = 0)
+		  AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		upd = `UPDATE "unitAliasLearnCandidates" SET "dismissedAt" = ?, "finalizedAt" = ?
+			WHERE "systemId" = ? AND "unitRef" = ?
+			  AND ("acceptedAt" IS NULL OR "acceptedAt" = 0)
+			  AND ("dismissedAt" IS NULL OR "dismissedAt" = 0)`
+		_, err = controller.Database.Sql.Exec(upd, now, now, sysId, unitRef)
+	} else {
+		_, err = controller.Database.Sql.Exec(upd, now, sysId, unitRef)
+	}
+	if err != nil {
+		return err
+	}
+
+	controller.Logs.LogEvent(LogLevelInfo, fmt.Sprintf(
+		"unit auto-learn: dismissed unitRef %d on system %d", unitRef, sysId,
+	))
+	return nil
+}
+
+func (controller *Controller) scanUnitAliasHistory(systemId uint64, hours, limit int) (*UnitAliasScanResponse, error) {
+	if controller == nil || controller.Database == nil {
+		return nil, fmt.Errorf("database unavailable")
+	}
+	if systemId == 0 {
+		return nil, fmt.Errorf("systemId is required")
+	}
+	sys, ok := controller.Systems.GetSystemById(systemId)
+	if !ok {
+		return nil, fmt.Errorf("system %d not found", systemId)
+	}
+
+	lookback := unitAliasScanDefaultHours
+	if hours > 0 {
+		lookback = hours
+	}
+	if lookback > unitAliasScanMaxHours {
+		lookback = unitAliasScanMaxHours
+	}
+	batchLimit := unitAliasScanDefaultLimit
+	if limit > 0 {
+		batchLimit = limit
+	}
+	if batchLimit > unitAliasScanMaxLimit {
+		batchLimit = unitAliasScanMaxLimit
+	}
+
+	callsRequired := controller.unitLearnCallsRequired()
+	resp := &UnitAliasScanResponse{
+		LookbackHours: lookback,
+		CallsRequired: callsRequired,
+		Suggestions:   []UnitAliasSuggestion{},
+	}
+
+	cutoff := time.Now().Add(-time.Duration(lookback) * time.Hour).UnixMilli()
+
+	query := `SELECT DISTINCT c."callId", c."talkgroupId", c."timestamp", COALESCE(c."transcript", '')
+		FROM "calls" c
+		INNER JOIN "callUnits" cu ON cu."callId" = c."callId"
+		WHERE c."systemId" = $1 AND c."timestamp" >= $2 AND cu."unitRef" > 0
+		ORDER BY c."timestamp" DESC
+		LIMIT $3`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		query = `SELECT DISTINCT c."callId", c."talkgroupId", c."timestamp", COALESCE(c."transcript", '')
+			FROM "calls" c
+			INNER JOIN "callUnits" cu ON cu."callId" = c."callId"
+			WHERE c."systemId" = ? AND c."timestamp" >= ? AND cu."unitRef" > 0
+			ORDER BY c."timestamp" DESC
+			LIMIT ?`
+	}
+
+	rows, err := controller.Database.Sql.Query(query, systemId, cutoff, batchLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type scanCall struct {
+		callId      uint64
+		talkgroupId uint64
+		timestamp   int64
+		transcript  string
+	}
+	var batch []scanCall
+	for rows.Next() {
+		var c scanCall
+		if err := rows.Scan(&c.callId, &c.talkgroupId, &c.timestamp, &c.transcript); err != nil {
+			return nil, err
+		}
+		batch = append(batch, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	beforeReady, _ := controller.listUnitAliasSuggestions(systemId, false)
+	beforeCount := len(beforeReady)
+
+	for _, item := range batch {
+		resp.CallsScanned++
+		tg, tgOk := sys.Talkgroups.GetTalkgroupById(item.talkgroupId)
+		if !tgOk || tg == nil || !tg.AutoLearnUnitAliases {
+			continue
+		}
+		if !sys.AlertsEnabled || !tg.AlertsEnabled {
+			continue
+		}
+
+		units, err := controller.loadCallUnitsForLearn(item.callId)
+		if err != nil || len(units) == 0 {
+			continue
+		}
+		resp.CallsWithUnits++
+
+		call := NewCall()
+		call.Id = item.callId
+		call.System = sys
+		call.Talkgroup = tg
+		call.Timestamp = time.UnixMilli(item.timestamp)
+		call.Transcript = item.transcript
+		call.Units = units
+		for _, u := range units {
+			call.Meta.UnitRefs = append(call.Meta.UnitRefs, u.UnitRef)
+			call.Meta.UnitLabels = append(call.Meta.UnitLabels, u.Label)
+		}
+		controller.processUnitAutoLearn(call, item.transcript)
+	}
+
+	suggestions, err := controller.listUnitAliasSuggestions(systemId, false)
+	if err != nil {
+		return nil, err
+	}
+	resp.Suggestions = suggestions
+	resp.CandidatesTouched = len(suggestions)
+	if len(suggestions) > beforeCount {
+		resp.CandidatesTouched = len(suggestions) // still useful as open count
+	}
+	ready := 0
+	for _, s := range suggestions {
+		if s.Ready {
+			ready++
+		}
+	}
+	resp.ReadyCount = ready
+	resp.Message = fmt.Sprintf(
+		"Scanned %d calls (%d with units) over %dh. %d suggestion(s) ready to review.",
+		resp.CallsScanned, resp.CallsWithUnits, lookback, ready,
+	)
+	return resp, nil
+}
+
+func (controller *Controller) loadCallUnitsForLearn(callId uint64) ([]CallUnit, error) {
+	q := `SELECT "unitRef", COALESCE("label", ''), "offset" FROM "callUnits" WHERE "callId" = $1 ORDER BY "offset"`
+	if controller.Database.Config.DbType != DbTypePostgresql {
+		q = `SELECT "unitRef", COALESCE("label", ''), "offset" FROM "callUnits" WHERE "callId" = ? ORDER BY "offset"`
+	}
+	rows, err := controller.Database.Sql.Query(q, callId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []CallUnit
+	for rows.Next() {
+		var u CallUnit
+		var offset float64
+		if err := rows.Scan(&u.UnitRef, &u.Label, &offset); err != nil {
+			return nil, err
+		}
+		u.CallId = callId
+		u.Offset = float32(offset)
+		if u.UnitRef > 0 {
+			out = append(out, u)
+		}
+	}
+	return out, rows.Err()
+}
+
+func (admin *Admin) UnitAliasSuggestionsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	token := admin.GetAuthorization(r)
+	if !admin.ValidateToken(token) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	systemId, _ := strconv.ParseUint(r.URL.Query().Get("systemId"), 10, 64)
+	if systemId == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"systemId is required"}`))
+		return
+	}
+	readyOnly := r.URL.Query().Get("ready") == "1"
+
+	list, err := admin.Controller.listUnitAliasSuggestions(systemId, readyOnly)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf(`{"error":"%s"}`, escapeQuotes(err.Error()))))
+		return
+	}
+
+	ready := 0
+	for _, s := range list {
+		if s.Ready {
+			ready++
+		}
+	}
+	resp := UnitAliasSuggestionsResponse{
+		Status: UnitAliasLearnStatus{
+			Enabled:       admin.Controller.systemHasUnitLearnEnabled(systemId),
+			CallsRequired: admin.Controller.unitLearnCallsRequired(),
+			PendingReady:  ready,
+			PendingAll:    len(list),
+		},
+		Suggestions: list,
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+}
+
+func (admin *Admin) UnitAliasSuggestionActionHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	token := admin.GetAuthorization(r)
+	if !admin.ValidateToken(token) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// /api/admin/unit-alias-suggestions/{id}/accept|dismiss
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 3 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	action := parts[len(parts)-1]
+	id, err := strconv.ParseUint(parts[len(parts)-2], 10, 64)
+	if err != nil || id == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	systemId, _ := strconv.ParseUint(r.URL.Query().Get("systemId"), 10, 64)
+
+	switch action {
+	case "accept":
+		var req UnitAliasAcceptRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if err := admin.Controller.acceptUnitAliasSuggestion(systemId, id, req.Label); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf(`{"error":"%s"}`, escapeQuotes(err.Error()))))
+			return
+		}
+	case "dismiss":
+		if err := admin.Controller.dismissUnitAliasSuggestion(systemId, id); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf(`{"error":"%s"}`, escapeQuotes(err.Error()))))
+			return
+		}
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (admin *Admin) UnitAliasHistoryScanHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	token := admin.GetAuthorization(r)
+	if !admin.ValidateToken(token) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var req UnitAliasScanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	result, err := admin.Controller.scanUnitAliasHistory(req.SystemId, req.Hours, req.Limit)
+	if err != nil {
+		admin.Controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("unit alias history scan failed: %s", err.Error()))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf(`{"error":"%s"}`, escapeQuotes(err.Error()))))
+		return
+	}
+
+	if b, err := json.Marshal(result); err == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
## Summary
Revamps auto-learn unit aliases into a find → review flow like call-nature phrase suggestions / tone history. Consistent P25 radio aliases still auto-add to the system Units list (Source column). OpenAI suggestions and conflicting aliases now queue for **Accept / Dismiss** on the system Units panel, with an optional **Scan recent history** backfill. Also clarifies the confusing tag rollout: empty tags enable all talkgroups.

## What happened
Unit/Source learning already existed, but it was hard to use and easy to misunderstand:

1. **Silent OpenAI writes / silent skips** — After enough calls, OpenAI labels were inserted into `units` with no review, while conflicts and `UNKNOWN` were finalized in logs only (no recover UI).
2. **“Tags to enable” looked like unit tagging** — Selecting tags only bulk-flipped `autoLearnUnitAliases` on talkgroups with those tags. With an empty tag list, the system toggle effectively did nothing.
3. **No history / suggestions surface** — Unlike tone history analyze, there was no admin list of pending unitRefs to Accept into Source.

## What this PR fixes
- Extends `unitAliasLearnCandidates` with `suggestedLabel`, `reason`, `usedOpenAI`, `acceptedAt`, `dismissedAt`.
- Live path: consistent P25 alias → auto-add; OpenAI / conflict / unknown → pending review (not silent finalize).
- Admin APIs: `GET /api/admin/unit-alias-suggestions`, accept/dismiss actions, `POST /api/admin/unit-alias-history-scan`.
- System Units panel: Ready / Emerging suggestions, editable label, Accept / Dismiss, Scan recent history.
- Tag rollout: empty tag list enables **all** talkgroups; selected tags remain a restrictor. Clearer labels/hints.
- Talkgroup caption updated to point at the system Units review panel.

## Testing
- [ ] Enable **Auto-learn unit aliases** on a system with tags empty → all talkgroups get the flag after save.
- [ ] Hear a unitRef with a consistent P25 alias across N calls → unit appears in Units / Source without Accept.
- [ ] Hear a unitRef that needs OpenAI → appears under Unit alias suggestions; Accept writes Units and Source resolves; Dismiss removes it.
- [ ] Conflict / unknown cases show as ready with a reason and allow entering a label to Accept.
- [ ] **Scan recent history** backfills candidates from recent `callUnits` traffic.
- [ ] Auto-off expiry with empty tags clears all talkgroup flags; with tags, only matching tags.

## Deferred
- Mirroring empty-tags-means-all for tone auto-learn tag UX.
- Relaxing the alerts-required gate for unit learn.
- Call-nature phrase learning merge (separate branch/PR).
