### PR TITLE
Add Users multi-select bulk delete and last-login sort

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/admin.service.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.service.ts
@@ -144,6 +144,7 @@ export interface User {
     accountExpiresAt?: string;
     pinExpiresAt?: string;
     lastLogin?: string;
+    lastLoginAt?: number;
     createdAt?: string;
     stripeCustomerId?: string;
     stripeSubscriptionId?: string;
@@ -2929,6 +2930,18 @@ export class RdioScannerAdminService implements OnDestroy {
       console.error('Failed to delete user:', error);
       throw error;
     }
+  }
+
+  async bulkDeleteUsers(userIds: number[]): Promise<{ deleted: number[]; failed: { id: number; error: string }[] }> {
+    const response = await firstValueFrom(this.ngHttpClient.post<{ deleted: number[]; failed: { id: number; error: string }[] }>(
+      this.getUrl('/users/bulk-delete'),
+      { userIds },
+      { headers: this.getHeaders(), responseType: 'json' }
+    ));
+    return {
+      deleted: response?.deleted || [],
+      failed: response?.failed || [],
+    };
   }
 
   async updateUser(userId: number, userData: any): Promise<any> {

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
@@ -79,6 +79,15 @@
             </mat-select>
         </mat-form-field>
 
+        <mat-form-field appearance="outline" class="filter-field">
+            <mat-label>Sort</mat-label>
+            <mat-select [(ngModel)]="sortMode" (selectionChange)="onSortModeChange()">
+                <mat-option value="name">Name A–Z</mat-option>
+                <mat-option value="lastLoginDesc">Last login (newest)</mat-option>
+                <mat-option value="lastLoginAsc">Last login (oldest)</mat-option>
+            </mat-select>
+        </mat-form-field>
+
         <button mat-button type="button" color="accent" *ngIf="hasActiveFilters" (click)="clearFilters()">
             <mat-icon>clear</mat-icon>
             Clear
@@ -87,6 +96,17 @@
         <span class="search-info mat-body-2" *ngIf="hasActiveFilters">
             {{ filteredUsers.length }} of {{ users.length }} users
         </span>
+    </div>
+
+    <div class="bulk-toolbar" *ngIf="!loading && !error && selectedCount > 0">
+        <span class="mat-body-2">{{ selectedCount }} selected</span>
+        <button type="button" mat-button (click)="clearSelection()">Deselect</button>
+        <button type="button" mat-raised-button color="warn"
+                (click)="bulkDeleteSelected()"
+                [disabled]="bulkDeleting">
+            <mat-icon>delete</mat-icon>
+            {{ bulkDeleting ? 'Deleting…' : 'Delete selected' }}
+        </button>
     </div>
 
     <!-- Loading State -->
@@ -111,6 +131,26 @@
     <!-- Users Table -->
     <div class="table-wrapper" *ngIf="!loading && !error && users.length > 0">
         <mat-table [dataSource]="paginatedUsers" multiTemplateDataRows class="users-table">
+
+            <!-- Select Column -->
+            <ng-container matColumnDef="select">
+                <th mat-header-cell *matHeaderCellDef class="select-col">
+                    <mat-checkbox
+                        color="primary"
+                        [checked]="allFilteredSelected"
+                        [indeterminate]="selectedCount > 0 && !allFilteredSelected"
+                        (change)="toggleSelectAllFiltered($event.checked)"
+                        [disabled]="filteredUsers.length === 0">
+                    </mat-checkbox>
+                </th>
+                <td mat-cell *matCellDef="let user" class="select-col" (click)="$event.stopPropagation()">
+                    <mat-checkbox
+                        color="primary"
+                        [checked]="isUserSelected(user)"
+                        (change)="toggleUserSelection(user, $event.checked)">
+                    </mat-checkbox>
+                </td>
+            </ng-container>
 
             <!-- Avatar Column -->
             <ng-container matColumnDef="avatar">

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.scss
@@ -66,6 +66,18 @@
         }
     }
 
+    .bulk-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 12px;
+        padding: 10px 12px;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.04);
+    }
+
     // ─── State Containers ──────────────────────────────────────────────────────
     .loading-container,
     .error-container,
@@ -152,6 +164,11 @@
 
     // Avatar column
     .avatar-col {
+        width: 48px;
+        padding: 0 4px 0 12px !important;
+    }
+
+    .select-col {
         width: 48px;
         padding: 0 4px 0 12px !important;
     }

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
@@ -44,6 +44,8 @@ export interface User {
     verified: boolean;
     createdAt: string;
     lastLogin: string;
+    /** Unix seconds; 0 = never logged in. Used for sorting. */
+    lastLoginAt?: number;
     firstName: string;
     lastName: string;
     zipCode: string;
@@ -88,12 +90,16 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     error: string | null = null;
 
     // Table columns
-    displayedColumns: string[] = ['avatar', 'user', 'group', 'status', 'pin', 'lastLogin', 'actions'];
+    displayedColumns: string[] = ['select', 'avatar', 'user', 'group', 'status', 'pin', 'lastLogin', 'actions'];
 
     // Expanded row for inline editing
     expandedUser: User | null = null;
 
-    // Search, filters, and pagination
+    // Multi-select for bulk actions
+    selectedUserIds = new Set<number>();
+    bulkDeleting = false;
+
+    // Search, filters, sort, and pagination
     searchText = '';
     /** '' = all, 'none' = no group, otherwise group id as string. */
     groupFilter = '';
@@ -101,6 +107,8 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     subscriptionFilter = '';
     /** '' = all; pin_expired | account_expired | verified | unverified. */
     statusFilter = '';
+    /** name | lastLoginDesc | lastLoginAsc */
+    sortMode: 'name' | 'lastLoginDesc' | 'lastLoginAsc' = 'name';
     filteredUsers: User[] = [];
     paginatedUsers: User[] = [];
     pageSize = 25;
@@ -243,6 +251,7 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
                 verified: user.verified || false,
                 createdAt: user.createdAt || '',
                 lastLogin: user.lastLogin || '',
+                lastLoginAt: Number(user.lastLoginAt) || 0,
                 systems: user.systems || '',
                 delay: user.delay || 0,
                 systemDelays: user.systemDelays || '',
@@ -279,9 +288,33 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     }
 
     private sortUsers(): void {
-        this.users.sort((a, b) =>
-            this.getUserSortKey(a).localeCompare(this.getUserSortKey(b), undefined, { sensitivity: 'base' })
-        );
+        this.users.sort((a, b) => {
+            if (this.sortMode === 'lastLoginDesc' || this.sortMode === 'lastLoginAsc') {
+                const aAt = Number(a.lastLoginAt) || 0;
+                const bAt = Number(b.lastLoginAt) || 0;
+                // Never-logged (0): last for newest-first, first for oldest-first.
+                if (aAt === 0 && bAt === 0) {
+                    return this.getUserSortKey(a).localeCompare(this.getUserSortKey(b), undefined, { sensitivity: 'base' });
+                }
+                if (aAt === 0) {
+                    return this.sortMode === 'lastLoginDesc' ? 1 : -1;
+                }
+                if (bAt === 0) {
+                    return this.sortMode === 'lastLoginDesc' ? -1 : 1;
+                }
+                const cmp = aAt - bAt;
+                if (cmp !== 0) {
+                    return this.sortMode === 'lastLoginDesc' ? -cmp : cmp;
+                }
+            }
+            return this.getUserSortKey(a).localeCompare(this.getUserSortKey(b), undefined, { sensitivity: 'base' });
+        });
+    }
+
+    onSortModeChange(): void {
+        this.pageIndex = 0;
+        this.sortUsers();
+        this.applyFilter();
     }
 
     async loadSystems(): Promise<void> {
@@ -608,6 +641,7 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
 
         try {
             await this.adminService.deleteUser(user.id);
+            this.selectedUserIds.delete(user.id);
             this.matSnackBar.open(`User ${user.email} deleted successfully`, 'Close', {
                 duration: 3000,
                 panelClass: ['success-snackbar']
@@ -618,12 +652,91 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
             if (this.form && this.form.parent) {
                 this.form.parent.markAsDirty();
             }
-        } catch (error) {
+        } catch (error: any) {
             console.error('Failed to delete user:', error);
-            this.matSnackBar.open('Failed to delete user', 'Close', {
-                duration: 3000,
+            const msg = error?.error?.error || error?.message || 'Failed to delete user';
+            this.matSnackBar.open(msg, 'Close', {
+                duration: 4000,
                 panelClass: ['error-snackbar']
             });
+        }
+    }
+
+    get selectedCount(): number {
+        return this.selectedUserIds.size;
+    }
+
+    get allFilteredSelected(): boolean {
+        return this.filteredUsers.length > 0
+            && this.filteredUsers.every(u => this.selectedUserIds.has(u.id));
+    }
+
+    isUserSelected(user: User): boolean {
+        return this.selectedUserIds.has(user.id);
+    }
+
+    toggleUserSelection(user: User, checked: boolean): void {
+        if (checked) {
+            this.selectedUserIds.add(user.id);
+        } else {
+            this.selectedUserIds.delete(user.id);
+        }
+    }
+
+    toggleSelectAllFiltered(checked: boolean): void {
+        if (checked) {
+            this.filteredUsers.forEach(u => this.selectedUserIds.add(u.id));
+        } else {
+            this.filteredUsers.forEach(u => this.selectedUserIds.delete(u.id));
+        }
+    }
+
+    clearSelection(): void {
+        this.selectedUserIds.clear();
+    }
+
+    async bulkDeleteSelected(): Promise<void> {
+        const ids = Array.from(this.selectedUserIds);
+        if (ids.length === 0 || this.bulkDeleting) {
+            return;
+        }
+        if (!confirm(`Delete ${ids.length} selected user${ids.length === 1 ? '' : 's'}? This cannot be undone.`)) {
+            return;
+        }
+
+        this.bulkDeleting = true;
+        try {
+            const result = await this.adminService.bulkDeleteUsers(ids);
+            const deleted = result.deleted?.length || 0;
+            const failed = result.failed?.length || 0;
+            this.selectedUserIds.clear();
+            if (failed === 0) {
+                this.matSnackBar.open(`Deleted ${deleted} user${deleted === 1 ? '' : 's'}.`, 'Close', {
+                    duration: 4000,
+                    panelClass: ['success-snackbar']
+                });
+            } else {
+                const firstErr = result.failed[0]?.error || 'unknown error';
+                this.matSnackBar.open(
+                    `Deleted ${deleted}, failed ${failed}. ${firstErr}`,
+                    'Close',
+                    { duration: 7000, panelClass: ['error-snackbar'] }
+                );
+            }
+            await this.loadUsers(true);
+            if (this.form && this.form.parent) {
+                this.form.parent.markAsDirty();
+            }
+        } catch (error: any) {
+            console.error('Bulk delete failed:', error);
+            const msg = error?.error?.error || error?.message || 'Bulk delete failed';
+            this.matSnackBar.open(msg, 'Close', {
+                duration: 5000,
+                panelClass: ['error-snackbar']
+            });
+        } finally {
+            this.bulkDeleting = false;
+            this.cdr.detectChanges();
         }
     }
 
@@ -990,11 +1103,13 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     // Search and pagination methods
     onSearchChange(): void {
         this.pageIndex = 0; // Reset to first page when search changes
+        this.clearSelection();
         this.applyFilter();
     }
 
     onFiltersChange(): void {
         this.pageIndex = 0;
+        this.clearSelection();
         this.applyFilter();
     }
 

--- a/server/admin.go
+++ b/server/admin.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -6245,18 +6246,23 @@ func (admin *Admin) UsersListHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Format lastLogin
+		var lastLoginAt int64
 		if user.LastLogin == "" || user.LastLogin == "0" {
 			lastLoginFormatted = "User has not logged in"
+			lastLoginAt = 0
 		} else {
 			if timestamp, err := strconv.ParseInt(user.LastLogin, 10, 64); err == nil {
 				// Check if timestamp is 0 (Unix epoch) which means never logged in
 				if timestamp == 0 {
 					lastLoginFormatted = "User has not logged in"
+					lastLoginAt = 0
 				} else {
 					lastLoginFormatted = time.Unix(timestamp, 0).Format("2006-01-02 15:04:05 MST")
+					lastLoginAt = timestamp
 				}
 			} else {
 				lastLoginFormatted = "User has not logged in" // fallback for invalid timestamps
+				lastLoginAt = 0
 			}
 		}
 
@@ -6297,6 +6303,7 @@ func (admin *Admin) UsersListHandler(w http.ResponseWriter, r *http.Request) {
 			"verified":                 user.Verified,
 			"createdAt":                createdAtFormatted,
 			"lastLogin":                lastLoginFormatted,
+			"lastLoginAt":              lastLoginAt,
 			"systems":                  user.Systems,
 			"delay":                    user.Delay,
 			"systemDelays":             user.SystemDelays,
@@ -6415,67 +6422,175 @@ func (admin *Admin) UserDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get user to check if exists
-	user := admin.Controller.Users.GetUserById(userID)
-	if user == nil {
-		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "User not found"})
+	if err := admin.deleteUserWithDeps(userID); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		} else if strings.Contains(err.Error(), "last system administrator") {
+			status = http.StatusBadRequest
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
 
-	// Delete user and all related records in a transaction
-	tx, err := admin.Controller.Database.Sql.Begin()
-	if err != nil {
-		log.Printf("Failed to begin transaction for user %d deletion: %v", userID, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to delete user from database"})
-		return
-	}
-
-	// Delete dependent records first (tables without ON DELETE CASCADE)
-	if _, err = tx.Exec(`DELETE FROM "userAlertPreferences" WHERE "userId" = $1`, userID); err != nil {
-		tx.Rollback()
-		log.Printf("Failed to delete userAlertPreferences for user %d: %v", userID, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to delete user from database"})
-		return
-	}
-	if _, err = tx.Exec(`DELETE FROM "deviceTokens" WHERE "userId" = $1`, userID); err != nil {
-		tx.Rollback()
-		log.Printf("Failed to delete deviceTokens for user %d: %v", userID, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to delete user from database"})
-		return
-	}
-
-	// Now delete the user
-	if _, err = tx.Exec(`DELETE FROM "users" WHERE "userId" = $1`, userID); err != nil {
-		tx.Rollback()
-		log.Printf("Failed to delete user %d from database: %v", userID, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to delete user from database"})
-		return
-	}
-
-	if err = tx.Commit(); err != nil {
-		tx.Rollback()
-		log.Printf("Failed to commit deletion transaction for user %d: %v", userID, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to delete user from database"})
-		return
-	}
-
-	// Remove user from in-memory map
-	if err := admin.Controller.Users.Remove(userID); err != nil {
-		log.Printf("Failed to remove user %d from memory: %v", userID, err)
-		// Don't fail the request since database deletion succeeded
-	}
-
-	// Sync config to file if enabled
 	admin.Controller.SyncConfigToFile()
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"message": "User deleted successfully"})
+}
+
+type usersBulkDeleteRequest struct {
+	UserIds []uint64 `json:"userIds"`
+}
+
+type usersBulkDeleteFailure struct {
+	Id    uint64 `json:"id"`
+	Error string `json:"error"`
+}
+
+type usersBulkDeleteResponse struct {
+	Deleted []uint64                 `json:"deleted"`
+	Failed  []usersBulkDeleteFailure `json:"failed"`
+}
+
+// UsersBulkDeleteHandler deletes many users with the same DB-safe cleanup as single delete.
+func (admin *Admin) UsersBulkDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	t := admin.GetAuthorization(r)
+	if !admin.ValidateToken(t) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var req usersBulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"})
+		return
+	}
+	if len(req.UserIds) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "userIds is required"})
+		return
+	}
+	if len(req.UserIds) > 500 {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "too many userIds (max 500)"})
+		return
+	}
+
+	deletingSet := map[uint64]bool{}
+	ordered := make([]uint64, 0, len(req.UserIds))
+	for _, id := range req.UserIds {
+		if id == 0 || deletingSet[id] {
+			continue
+		}
+		deletingSet[id] = true
+		ordered = append(ordered, id)
+	}
+
+	// Delete non-admins first so bulk can remove extra system admins while still
+	// refusing to remove the final remaining system administrator.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		ui := admin.Controller.Users.GetUserById(ordered[i])
+		uj := admin.Controller.Users.GetUserById(ordered[j])
+		ai := ui != nil && ui.SystemAdmin
+		aj := uj != nil && uj.SystemAdmin
+		if ai == aj {
+			return false
+		}
+		return !ai && aj
+	})
+
+	resp := usersBulkDeleteResponse{
+		Deleted: []uint64{},
+		Failed:  []usersBulkDeleteFailure{},
+	}
+	for _, id := range ordered {
+		if err := admin.deleteUserWithDeps(id); err != nil {
+			resp.Failed = append(resp.Failed, usersBulkDeleteFailure{Id: id, Error: err.Error()})
+			continue
+		}
+		resp.Deleted = append(resp.Deleted, id)
+	}
+
+	admin.Controller.SyncConfigToFile()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// deleteUserWithDeps removes alert prefs + device tokens + the user row in one transaction,
+// then clears in-memory user/token state. Refuses to delete the last system administrator.
+func (admin *Admin) deleteUserWithDeps(userID uint64) error {
+	if admin == nil || admin.Controller == nil || admin.Controller.Database == nil {
+		return fmt.Errorf("server not ready")
+	}
+	if userID == 0 {
+		return fmt.Errorf("invalid user id")
+	}
+
+	user := admin.Controller.Users.GetUserById(userID)
+	if user == nil {
+		return fmt.Errorf("user not found")
+	}
+	if admin.wouldLeaveNoSystemAdmin(userID) {
+		return fmt.Errorf("cannot delete the last system administrator")
+	}
+
+	tx, err := admin.Controller.Database.Sql.Begin()
+	if err != nil {
+		log.Printf("Failed to begin transaction for user %d deletion: %v", userID, err)
+		return fmt.Errorf("failed to delete user from database")
+	}
+
+	if _, err = tx.Exec(`DELETE FROM "userAlertPreferences" WHERE "userId" = $1`, userID); err != nil {
+		tx.Rollback()
+		log.Printf("Failed to delete userAlertPreferences for user %d: %v", userID, err)
+		return fmt.Errorf("failed to delete user from database")
+	}
+	if _, err = tx.Exec(`DELETE FROM "deviceTokens" WHERE "userId" = $1`, userID); err != nil {
+		tx.Rollback()
+		log.Printf("Failed to delete deviceTokens for user %d: %v", userID, err)
+		return fmt.Errorf("failed to delete user from database")
+	}
+	if _, err = tx.Exec(`DELETE FROM "users" WHERE "userId" = $1`, userID); err != nil {
+		tx.Rollback()
+		log.Printf("Failed to delete user %d from database: %v", userID, err)
+		return fmt.Errorf("failed to delete user from database")
+	}
+	if err = tx.Commit(); err != nil {
+		tx.Rollback()
+		log.Printf("Failed to commit deletion transaction for user %d: %v", userID, err)
+		return fmt.Errorf("failed to delete user from database")
+	}
+
+	if admin.Controller.DeviceTokens != nil {
+		admin.Controller.DeviceTokens.PurgeUserMemory(userID, admin.Controller.Clients)
+	}
+	if err := admin.Controller.Users.Remove(userID); err != nil {
+		log.Printf("Failed to remove user %d from memory: %v", userID, err)
+	}
+	return nil
+}
+
+func (admin *Admin) wouldLeaveNoSystemAdmin(userID uint64) bool {
+	user := admin.Controller.Users.GetUserById(userID)
+	if user == nil || !user.SystemAdmin {
+		return false
+	}
+	for _, other := range admin.Controller.Users.GetAllUsers() {
+		if other != nil && other.SystemAdmin && other.Id != userID {
+			return false
+		}
+	}
+	return true
 }
 
 // UserUpdateHandler handles PUT requests to update a user

--- a/server/device_token.go
+++ b/server/device_token.go
@@ -261,6 +261,45 @@ func (dt *DeviceTokens) Delete(id uint64, db *Database, clients *Clients) error 
 	return nil
 }
 
+// PurgeUserMemory removes all in-memory device tokens for a user after their DB rows
+// were already deleted (e.g. user account deletion). Also clears linked client sessions.
+func (dt *DeviceTokens) PurgeUserMemory(userId uint64, clients *Clients) {
+	if dt == nil || userId == 0 {
+		return
+	}
+
+	dt.mutex.Lock()
+	tokens := dt.userTokens[userId]
+	var clearedKeys []string
+	for _, token := range tokens {
+		if token == nil {
+			continue
+		}
+		pushKey := token.FCMToken
+		if pushKey == "" {
+			pushKey = token.Token
+		}
+		if pushKey != "" {
+			clearedKeys = append(clearedKeys, pushKey)
+		}
+		delete(dt.tokens, token.Id)
+		if token.FCMToken != "" {
+			delete(dt.tokenIndex, token.FCMToken)
+		}
+		if token.Token != "" {
+			delete(dt.tokenIndex, token.Token)
+		}
+	}
+	delete(dt.userTokens, userId)
+	dt.mutex.Unlock()
+
+	if clients != nil {
+		for _, k := range clearedKeys {
+			clients.ClearSessionsForPushToken(k)
+		}
+	}
+}
+
 func (dt *DeviceTokens) GetByUser(userId uint64) []*DeviceToken {
 	dt.mutex.RLock()
 	defer dt.mutex.RUnlock()

--- a/server/main.go
+++ b/server/main.go
@@ -451,6 +451,7 @@ func main() {
 
 	http.HandleFunc("/api/admin/users", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.UsersListHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/users/create", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.UserCreateHandler)).ServeHTTP)
+	http.HandleFunc("/api/admin/users/bulk-delete", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.UsersBulkDeleteHandler)).ServeHTTP)
 	http.HandleFunc("/api/admin/users/", wrapHandler(controller.Admin.requireLocalhost(func(w http.ResponseWriter, r *http.Request) {
 		// Check if it's a device-tokens endpoint: /api/admin/users/{userId}/device-tokens/{tokenId}
 		pathParts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")


### PR DESCRIPTION
## Summary
Admin → Users now supports multi-select bulk delete and sorting by last login. Bulk delete reuses the same transactional cleanup as single delete (alert prefs + device tokens + user row) so related tables do not leave orphan FK failures, and refuses to remove the last system administrator.

## What happened
The Users table allowed search/filters and name A–Z sorting, but not multi-select or last-login sort. Deleting users one-by-one was the only path. Last login was returned only as a formatted display string, so client-side date sorting was unreliable. Device token rows were deleted in SQL on user delete, but in-memory token maps were not always cleared.

## What this PR fixes
- Adds checkbox multi-select (select all filtered) and a **Delete selected** toolbar with confirm.
- Adds `POST /api/admin/users/bulk-delete` sharing `deleteUserWithDeps` with single delete: transaction deletes `userAlertPreferences` → `deviceTokens` → `users`, then `Users.Remove` + `DeviceTokens.PurgeUserMemory`.
- Guards against deleting the last remaining system admin (bulk processes non-admins first so extra admins can still be removed).
- Returns numeric `lastLoginAt` from `GET /api/admin/users` and adds Sort: Name / Last login newest / oldest.
- Clears selection when filters/search change.

## Testing
- [ ] Select several non-admin users → Delete selected → users gone; no FK errors in logs.
- [ ] Attempt to delete the only system admin (alone or in a batch that would remove all admins) → blocked with clear error; other selected non-admins still delete.
- [ ] Sort by last login newest/oldest; never-logged users sort to the end/start as expected.
- [ ] Single-user delete from the row menu still works.
- [ ] After delete, push tokens for that user are gone from memory (no stale push targeting).

## Deferred
- Cancelling Stripe subscriptions on user delete (same as single delete today).
- Disconnecting live websocket clients for deleted users.
