### PR TITLE
Replace admin Users PIN column with expired status chips

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
@@ -210,12 +210,18 @@
             <div class="status-chips">
               <span class="chip" [class.chip-success]="user.verified" [class.chip-warn]="!user.verified">
                 <mat-icon>{{ user.verified ? 'verified' : 'pending' }}</mat-icon>
-                {{ user.verified ? 'Verified' : 'Pending' }}
+                {{ user.verified ? 'Verified' : 'Unverified' }}
               </span>
               @if (user.systemAdmin) {
                 <span class="chip chip-primary">
                   <mat-icon>admin_panel_settings</mat-icon>
                   Sys Admin
+                </span>
+              }
+              @if (user.isGroupAdmin) {
+                <span class="chip chip-warn">
+                  <mat-icon>manage_accounts</mat-icon>
+                  Group Admin
                 </span>
               }
               @if (user.forcePasswordReset) {
@@ -232,29 +238,20 @@
               }
               @if (user.subscriptionStatus) {
                 <span class="chip"
-                  [class.chip-success]="user.subscriptionStatus === 'active' || user.subscriptionStatus === 'trialing'"
-                  [class.chip-error]="user.subscriptionStatus === 'canceled' || user.subscriptionStatus === 'unpaid' || user.subscriptionStatus === 'past_due'"
-                  [class.chip-warn]="user.subscriptionStatus === 'incomplete'">
-                  {{ user.subscriptionStatus | titlecase }}
+                  [class.chip-success]="isSubscriptionOk(user.subscriptionStatus)"
+                  [class.chip-error]="isSubscriptionProblem(user.subscriptionStatus)"
+                  [class.chip-warn]="isSubscriptionWarn(user.subscriptionStatus)">
+                  {{ formatSubscriptionStatus(user.subscriptionStatus) }}
                 </span>
               }
-            </div>
-          </td>
-        </ng-container>
-        <!-- PIN Column -->
-        <ng-container matColumnDef="pin">
-          <th mat-header-cell *matHeaderCellDef>PIN</th>
-          <td mat-cell *matCellDef="let user">
-            <div class="pin-cell">
-              <code class="pin-code">{{ user.pin || '—' }}</code>
-              @if (user.pinExpired) {
-                <span class="pin-expired">
-                  <mat-icon>warning</mat-icon> Expired
+              @if (isPinExpired(user)) {
+                <span class="chip chip-pin-expired">
+                  PIN EXPIRED
                 </span>
               }
-              @if (user.pinExpiresAt && !user.pinExpired) {
-                <span class="pin-expiry muted">
-                  Exp: {{ formatPinExpiration(user.pinExpiresAt) }}
+              @if (isAccountExpired(user)) {
+                <span class="chip chip-pin-expired">
+                  ACCOUNT EXPIRED
                 </span>
               }
             </div>

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.scss
@@ -522,48 +522,13 @@
             color: #aaa;
             border: 1px solid #333;
         }
-    }
 
-    // PIN cell
-    .pin-cell {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-        min-width: 0;
-
-        .pin-code {
-            font-family: 'Roboto Mono', 'Courier New', monospace;
-            font-size: 12px;
-            color: #e0e0e0;
-            background: rgba(255, 255, 255, 0.05);
-            padding: 1px 6px;
-            border-radius: 4px;
-            border: 1px solid #333;
-            letter-spacing: 0.5px;
-            display: inline-block;
-            max-width: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-
-        .pin-expired {
-            display: flex;
-            align-items: center;
-            gap: 3px;
-            font-size: 11px;
+        &.chip-pin-expired {
+            background: rgba(244, 67, 54, 0.18);
             color: #f44336;
-            font-weight: 500;
-
-            mat-icon {
-                font-size: 12px;
-                width: 12px;
-                height: 12px;
-            }
-        }
-
-        .pin-expiry {
-            font-size: 10px;
+            border: 1px solid rgba(244, 67, 54, 0.55);
+            font-weight: 700;
+            letter-spacing: 0.04em;
         }
     }
 

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
@@ -93,7 +93,7 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     error: string | null = null;
 
     // Table columns
-    displayedColumns: string[] = ['select', 'avatar', 'user', 'group', 'status', 'pin', 'lastLogin', 'actions'];
+    displayedColumns: string[] = ['select', 'avatar', 'user', 'group', 'status', 'lastLogin', 'actions'];
 
     // Expanded row for inline editing
     expandedUser: User | null = null;
@@ -278,7 +278,10 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
                 stripeSubscriptionId: user.stripeSubscriptionId || '',
                 subscriptionStatus: user.subscriptionStatus || '',
                 accountExpiresAt: user.accountExpiresAt || 0,
-                pinExpired: false // Will be calculated if needed
+                pinExpired: !!user.pinExpired,
+            })).map((user: User) => ({
+                ...user,
+                pinExpired: this.isPinExpired(user),
             }));
             this.sortUsers();
             this.applyFilter();
@@ -643,7 +646,10 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
 
         try {
             const users = await this.adminService.getAllUsers();
-            this.users = users;
+            this.users = users.map((user: User) => ({
+                ...user,
+                pinExpired: this.isPinExpired(user),
+            }));
             this.sortUsers();
 
             // Also update the parent form if it exists
@@ -1212,8 +1218,7 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
             case 'trialing':
                 return status === 'trialing';
             case 'problem':
-                return status === 'past_due' || status === 'unpaid'
-                    || status === 'incomplete' || status === 'incomplete_expired';
+                return this.isSubscriptionProblem(status);
             case 'canceled':
                 return status === 'canceled' || status === 'cancelled';
             case 'none':
@@ -1224,12 +1229,11 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     }
 
     private matchesStatusFilter(user: User): boolean {
-        const now = Math.floor(Date.now() / 1000);
         switch (this.statusFilter) {
             case 'pin_expired':
-                return !!user.pinExpired;
+                return this.isPinExpired(user);
             case 'account_expired':
-                return !!(user.accountExpiresAt && user.accountExpiresAt > 0 && user.accountExpiresAt < now);
+                return this.isAccountExpired(user);
             case 'suspended':
                 return !!user.suspended;
             case 'verified':
@@ -1239,6 +1243,46 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
             default:
                 return true;
         }
+    }
+
+    /** True when the listener PIN expiration timestamp is in the past. */
+    isPinExpired(user: User): boolean {
+        if (user?.pinExpired) {
+            return true;
+        }
+        const expiresAt = Number(user?.pinExpiresAt) || 0;
+        return expiresAt > 0 && Math.floor(Date.now() / 1000) > expiresAt;
+    }
+
+    /** True when the account expiration timestamp is in the past. */
+    isAccountExpired(user: User): boolean {
+        const expiresAt = Number(user?.accountExpiresAt) || 0;
+        return expiresAt > 0 && Math.floor(Date.now() / 1000) > expiresAt;
+    }
+
+    isSubscriptionOk(status: string): boolean {
+        const s = (status || '').toLowerCase();
+        return s === 'active' || s === 'trialing';
+    }
+
+    isSubscriptionProblem(status: string): boolean {
+        const s = (status || '').toLowerCase();
+        return s === 'past_due' || s === 'unpaid'
+            || s === 'canceled' || s === 'cancelled'
+            || s === 'incomplete_expired';
+    }
+
+    isSubscriptionWarn(status: string): boolean {
+        const s = (status || '').toLowerCase();
+        return s === 'incomplete' || s === 'paused';
+    }
+
+    formatSubscriptionStatus(status: string): string {
+        const s = (status || '').trim();
+        if (!s) {
+            return '';
+        }
+        return s.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
     }
 
     private matchesGroupFilter(user: User): boolean {

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
@@ -1218,7 +1218,10 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
             case 'trialing':
                 return status === 'trialing';
             case 'problem':
-                return this.isSubscriptionProblem(status);
+                // Keep Problem distinct from Canceled: include incomplete billing
+                // states here; canceled users are filtered via the Canceled option.
+                return status === 'past_due' || status === 'unpaid'
+                    || status === 'incomplete' || status === 'incomplete_expired';
             case 'canceled':
                 return status === 'canceled' || status === 'cancelled';
             case 'none':


### PR DESCRIPTION
## Summary
- Removes the plaintext PIN column from Admin → Users.
- Status column now stacks every applicable chip: Verified/Unverified, Sys Admin, Group Admin, Password Reset Required, Suspended, subscription state, **PIN EXPIRED**, and **ACCOUNT EXPIRED**.
- PIN/account expiry helpers also drive the existing status filters so expired users show correctly.
