### PR TITLE
Add admin live listeners roster grouped by user

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/admin.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.component.ts
@@ -108,6 +108,7 @@ const SETTINGS_INDEX: SearchResult[] = [
     { label: 'Keyword Lists', keywords: 'keyword list alert word filter transcription', breadcrumb: 'Options → Keyword Lists', icon: 'list', configSection: 'keyword-lists' },
     // ── Operations ────────────────────────────────────────────────────────────
     { label: 'Logs', keywords: 'logs errors warnings info system log', breadcrumb: 'Logs', icon: 'article', configSection: 'logs' },
+    { label: 'Listeners', keywords: 'listeners listening connected online users devices who is listening roster', breadcrumb: 'Listeners', icon: 'headset', configSection: 'listeners' },
     { label: 'System Health', keywords: 'system health status disk cpu memory alerts', breadcrumb: 'System Health', icon: 'health_and_safety', configSection: 'system-health' },
     { label: 'Import Talkgroups', keywords: 'import talkgroups csv json file upload', breadcrumb: 'Tools → Import Talkgroups', icon: 'description', configSection: 'tools', toolSection: 'import-talkgroups' },
     { label: 'Import Units', keywords: 'import units csv json file upload', breadcrumb: 'Tools → Import Units', icon: 'description', configSection: 'tools', toolSection: 'import-units' },

--- a/client/src/app/components/rdio-scanner/admin/admin.module.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.module.ts
@@ -71,6 +71,7 @@ import { RdioScannerAdminRadioReferenceImportComponent } from './tools/radio-ref
 import { RdioScannerAdminStripeSyncComponent } from './tools/stripe-sync/stripe-sync.component';
 import { RdioScannerAdminPurgeDataComponent } from './tools/purge-data/purge-data.component';
 import { RdioScannerAdminSystemHealthComponent } from './system-health/system-health.component';
+import { RdioScannerAdminListenersComponent } from './listeners/listeners.component';
 import { RdioScannerAdminCentralManagementComponent } from './central-management/central-management.component';
 import { RdioScannerAdminAssistantComponent } from './assistant/assistant.component';
 import { RdioScannerAdminMappingDataComponent } from './config/mapping-data/mapping-data.component';
@@ -122,6 +123,7 @@ import { TalkgroupLocationDialogComponent } from './config/systems/system/talkgr
         RdioScannerAdminStripeSyncComponent,
         RdioScannerAdminPurgeDataComponent,
         RdioScannerAdminSystemHealthComponent,
+        RdioScannerAdminListenersComponent,
         RdioScannerAdminCentralManagementComponent,
         RdioScannerAdminAssistantComponent,
         RdioScannerAdminMappingDataComponent,

--- a/client/src/app/components/rdio-scanner/admin/admin.service.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.service.ts
@@ -741,6 +741,31 @@ export interface Unit {
     unitTo?: number;
 }
 
+export interface ListenerDeviceSnapshot {
+    ip: string;
+    clientKind: 'web' | 'mobile' | string;
+    livefeedActive: boolean;
+    connectedAt: string;
+    pinExpired: boolean;
+}
+
+export interface ListenerUserSnapshot {
+    userId: number;
+    email: string;
+    firstName: string;
+    lastName: string;
+    anonymous?: boolean;
+    deviceCount: number;
+    devices: ListenerDeviceSnapshot[];
+}
+
+export interface ListenersSnapshot {
+    totalConnections: number;
+    uniqueUsers: number;
+    anonymousConnections: number;
+    listeners: ListenerUserSnapshot[];
+}
+
 enum url {
     alerts = 'alerts',
     alertRetentionDays = 'alert-retention-days',
@@ -756,6 +781,7 @@ enum url {
     password = 'password',
     purge = 'purge',
     systemhealth = 'systemhealth',
+    listeners = 'listeners',
     systemNoAudioSettings = 'system-no-audio-settings',
     systemRetentionSettings = 'system-retention-settings',
     systemDuplicateDetectionSettings = 'system-duplicate-detection-settings',
@@ -1011,6 +1037,19 @@ export class RdioScannerAdminService implements OnDestroy {
         try {
             const res = await firstValueFrom(this.ngHttpClient.get<{ alerts: any[], count: number }>(
                 `${this.getUrl(url.systemhealth)}&limit=${limit}&includeDismissed=${includeDismissed}`,
+                { headers: this.getHeaders(), responseType: 'json' },
+            ));
+            return res;
+        } catch (error) {
+            this.errorHandler(error);
+            throw error;
+        }
+    }
+
+    async getListeners(): Promise<ListenersSnapshot> {
+        try {
+            const res = await firstValueFrom(this.ngHttpClient.get<ListenersSnapshot>(
+                this.getUrl(url.listeners),
                 { headers: this.getHeaders(), responseType: 'json' },
             ));
             return res;

--- a/client/src/app/components/rdio-scanner/admin/config/config.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/config.component.html
@@ -144,6 +144,13 @@
     </button>
 
     <button type="button" class="sidebar-item"
+      [class.active]="activeSection === 'listeners'"
+      (click)="setSection('listeners')">
+      <mat-icon>headset</mat-icon>
+      <span>Listeners</span>
+    </button>
+
+    <button type="button" class="sidebar-item"
       [class.active]="activeSection === 'system-health'"
       (click)="setSection('system-health')">
       <mat-icon>health_and_safety</mat-icon>
@@ -180,6 +187,8 @@
 
     @if (activeSection === 'logs') {
       <rdio-scanner-admin-logs #logsComponent></rdio-scanner-admin-logs>
+    } @else if (activeSection === 'listeners') {
+      <rdio-scanner-admin-listeners></rdio-scanner-admin-listeners>
     } @else if (activeSection === 'system-health') {
       <rdio-scanner-admin-system-health></rdio-scanner-admin-system-health>
     } @else if (activeSection === 'tools') {

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.html
@@ -238,6 +238,16 @@
                   {{ user.subscriptionStatus | titlecase }}
                 </span>
               }
+              @if (listeningDeviceCount(user) > 0) {
+                <span class="chip chip-listening">
+                  <mat-icon>headset</mat-icon>
+                  @if (listeningDeviceCount(user) > 1) {
+                    Listening · {{ listeningDeviceCount(user) }} devices
+                  } @else {
+                    Listening
+                  }
+                </span>
+              }
             </div>
           </td>
         </ng-container>

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.scss
@@ -522,6 +522,13 @@
             color: #aaa;
             border: 1px solid #333;
         }
+
+        &.chip-listening {
+            background: rgba(59, 130, 246, 0.16);
+            color: #93c5fd;
+            border: 1px solid rgba(59, 130, 246, 0.4);
+            font-weight: 600;
+        }
     }
 
     // PIN cell

--- a/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/users/users.component.ts
@@ -116,6 +116,10 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     paginatedUsers: User[] = [];
     pageSize = 25;
     pageIndex = 0;
+
+    /** userId -> live device count from /api/admin/listeners */
+    listeningDeviceCounts = new Map<number, number>();
+    private listenersPollTimer: ReturnType<typeof setInterval> | null = null;
     
     // Editing functionality
     editingUser: User | null = null;
@@ -234,6 +238,10 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
         this.loadGroups();
         this.loadSystems();
         this.loadApikeys();
+        void this.refreshListeningCounts();
+        this.listenersPollTimer = setInterval(() => {
+            void this.refreshListeningCounts();
+        }, 10000);
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -628,7 +636,34 @@ export class RdioScannerAdminUsersComponent implements OnInit, OnDestroy, OnChan
     }
 
     ngOnDestroy(): void {
-        // Cleanup if needed
+        if (this.listenersPollTimer) {
+            clearInterval(this.listenersPollTimer);
+            this.listenersPollTimer = null;
+        }
+    }
+
+    private async refreshListeningCounts(): Promise<void> {
+        try {
+            const snapshot = await this.adminService.getListeners();
+            const next = new Map<number, number>();
+            for (const listener of snapshot?.listeners || []) {
+                if (listener.anonymous || !listener.userId) {
+                    continue;
+                }
+                next.set(listener.userId, listener.deviceCount || listener.devices?.length || 0);
+            }
+            this.listeningDeviceCounts = next;
+            this.cdr.detectChanges();
+        } catch {
+            // Non-fatal: Users table still works without live listening chips.
+        }
+    }
+
+    listeningDeviceCount(user: User): number {
+        if (!user?.id) {
+            return 0;
+        }
+        return this.listeningDeviceCounts.get(user.id) || 0;
     }
 
     async loadUsers(forceReload: boolean = false): Promise<void> {

--- a/client/src/app/components/rdio-scanner/admin/listeners/listeners.component.html
+++ b/client/src/app/components/rdio-scanner/admin/listeners/listeners.component.html
@@ -1,0 +1,118 @@
+<!--
+* *****************************************************************************
+* Copyright (C) 2025 Thinline Dynamic Solutions
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>
+* ****************************************************************************
+-->
+<div class="listeners-container">
+  <div class="listeners-header">
+    <div class="listeners-title-block">
+      <h2>Live Listeners</h2>
+      <p class="listeners-hint">Who is connected right now. Multi-device sessions are grouped under one user.</p>
+    </div>
+    <button type="button" mat-stroked-button color="primary" (click)="refresh(true)" [disabled]="loading">
+      <mat-icon>refresh</mat-icon>
+      Refresh
+    </button>
+  </div>
+
+  @if (snapshot) {
+    <div class="stats-grid">
+      <div class="stat-card">
+        <h3>Connections</h3>
+        <div class="value">{{ snapshot.totalConnections }}</div>
+      </div>
+      <div class="stat-card">
+        <h3>Users</h3>
+        <div class="value">{{ snapshot.uniqueUsers }}</div>
+      </div>
+      <div class="stat-card">
+        <h3>Anonymous</h3>
+        <div class="value">{{ snapshot.anonymousConnections }}</div>
+      </div>
+    </div>
+  }
+
+  @if (loading && !snapshot) {
+    <div class="state-block">
+      <mat-spinner diameter="36"></mat-spinner>
+      <p>Loading listeners…</p>
+    </div>
+  }
+
+  @if (error) {
+    <div class="state-block error">
+      <mat-icon>error</mat-icon>
+      <p>{{ error }}</p>
+      <button type="button" mat-button color="primary" (click)="refresh(true)">Retry</button>
+    </div>
+  }
+
+  @if (snapshot && !error && snapshot.listeners.length === 0) {
+    <div class="state-block">
+      <mat-icon>headset_off</mat-icon>
+      <p>No listeners connected</p>
+    </div>
+  }
+
+  @if (snapshot && snapshot.listeners.length > 0) {
+    <div class="listeners-list">
+      @for (user of snapshot.listeners; track trackUser($index, user)) {
+        <div class="listener-row" [class.anonymous]="user.anonymous" [class.multi]="user.deviceCount > 1">
+          <button type="button" class="listener-summary" (click)="toggleExpanded(user)">
+            <mat-icon class="expand-icon">{{ isExpanded(user) ? 'expand_more' : 'chevron_right' }}</mat-icon>
+            <div class="listener-identity">
+              <span class="listener-name">{{ displayName(user) }}</span>
+              @if (!user.anonymous && user.email) {
+                <span class="listener-email">{{ user.email }}</span>
+              }
+            </div>
+            <div class="listener-badges">
+              @if (user.deviceCount > 1) {
+                <span class="badge badge-multi">{{ user.deviceCount }} devices</span>
+              } @else {
+                <span class="badge badge-single">1 device</span>
+              }
+              @if (user.anonymous) {
+                <span class="badge badge-anon">Anonymous</span>
+              }
+            </div>
+          </button>
+
+          @if (isExpanded(user)) {
+            <div class="device-list">
+              @for (device of user.devices; track device.ip + device.connectedAt + device.clientKind) {
+                <div class="device-row">
+                  <span class="device-kind" [class.mobile]="device.clientKind === 'mobile'">
+                    <mat-icon>{{ device.clientKind === 'mobile' ? 'smartphone' : 'computer' }}</mat-icon>
+                    {{ kindLabel(device.clientKind) }}
+                  </span>
+                  <span class="device-ip">{{ device.ip || '—' }}</span>
+                  <span class="device-feed" [class.active]="device.livefeedActive">
+                    {{ device.livefeedActive ? 'Livefeed on' : 'Livefeed off' }}
+                  </span>
+                  <span class="device-age">{{ connectedDuration(device.connectedAt) }}</span>
+                  @if (device.pinExpired) {
+                    <span class="device-pin-expired">PIN expired</span>
+                  }
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/client/src/app/components/rdio-scanner/admin/listeners/listeners.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/listeners/listeners.component.scss
@@ -1,0 +1,285 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2025 Thinline Dynamic Solutions
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+:host {
+    display: block;
+}
+
+.listeners-container {
+    padding: 12px 14px 14px;
+}
+
+.listeners-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.listeners-title-block {
+    h2 {
+        margin: 0 0 4px;
+        font-size: 1.15rem;
+        font-weight: 600;
+        color: #eee;
+    }
+}
+
+.listeners-hint {
+    margin: 0;
+    color: #999;
+    font-size: 0.82rem;
+    line-height: 1.45;
+    max-width: 42rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 12px;
+
+    @media (max-width: 640px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.stat-card {
+    background: #1a1a1a;
+    border-radius: 6px;
+    padding: 8px 10px;
+    border: 1px solid #2a2a2a;
+    border-left: 3px solid #3b82f6;
+
+    h3 {
+        margin: 0;
+        font-size: 0.65rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #888;
+        font-weight: 500;
+    }
+
+    .value {
+        margin-top: 4px;
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: #fff;
+        font-variant-numeric: tabular-nums;
+    }
+}
+
+.state-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    padding: 2.5rem 1rem;
+    color: #999;
+    text-align: center;
+
+    mat-icon {
+        font-size: 32px;
+        width: 32px;
+        height: 32px;
+        color: #555;
+    }
+
+    &.error {
+        color: #ef9a9a;
+
+        mat-icon {
+            color: #f44336;
+        }
+    }
+}
+
+.listeners-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.listener-row {
+    background: #1a1a1a;
+    border: 1px solid #2a2a2a;
+    border-radius: 6px;
+    overflow: hidden;
+
+    &.multi {
+        border-color: rgba(59, 130, 246, 0.35);
+    }
+
+    &.anonymous {
+        border-style: dashed;
+    }
+}
+
+.listener-summary {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.7rem 0.85rem;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.03);
+    }
+}
+
+.expand-icon {
+    color: #777;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+}
+
+.listener-identity {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+}
+
+.listener-name {
+    font-weight: 600;
+    color: #fff;
+    font-size: 0.92rem;
+}
+
+.listener-email {
+    font-size: 0.75rem;
+    color: #999;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.listener-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: flex-end;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+
+    &.badge-multi {
+        background: rgba(59, 130, 246, 0.18);
+        color: #93c5fd;
+        border: 1px solid rgba(59, 130, 246, 0.4);
+    }
+
+    &.badge-single {
+        background: rgba(255, 255, 255, 0.05);
+        color: #aaa;
+        border: 1px solid #333;
+    }
+
+    &.badge-anon {
+        background: rgba(255, 193, 7, 0.12);
+        color: #ffd54f;
+        border: 1px solid rgba(255, 193, 7, 0.3);
+    }
+}
+
+.device-list {
+    border-top: 1px solid #252525;
+    padding: 0.35rem 0.85rem 0.7rem 2.4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.device-row {
+    display: grid;
+    grid-template-columns: 7rem minmax(0, 1.2fr) 7rem 4rem auto;
+    gap: 0.55rem;
+    align-items: center;
+    font-size: 0.78rem;
+    color: #bbb;
+    padding: 0.35rem 0;
+
+    @media (max-width: 720px) {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.3rem 0.75rem;
+    }
+}
+
+.device-kind {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: #ddd;
+    font-weight: 500;
+
+    mat-icon {
+        font-size: 15px;
+        width: 15px;
+        height: 15px;
+        color: #888;
+    }
+
+    &.mobile mat-icon {
+        color: #60a5fa;
+    }
+}
+
+.device-ip {
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    color: #ccc;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.device-feed {
+    color: #777;
+
+    &.active {
+        color: #81c784;
+        font-weight: 600;
+    }
+}
+
+.device-age {
+    font-variant-numeric: tabular-nums;
+    color: #999;
+}
+
+.device-pin-expired {
+    color: #f44336;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    font-size: 0.7rem;
+}

--- a/client/src/app/components/rdio-scanner/admin/listeners/listeners.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/listeners/listeners.component.ts
@@ -1,0 +1,143 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2025 Thinline Dynamic Solutions
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import {
+    ListenerUserSnapshot,
+    ListenersSnapshot,
+    RdioScannerAdminService,
+} from '../admin.service';
+
+@Component({
+    selector: 'rdio-scanner-admin-listeners',
+    templateUrl: './listeners.component.html',
+    styleUrls: ['./listeners.component.scss'],
+    standalone: false,
+})
+export class RdioScannerAdminListenersComponent implements OnInit, OnDestroy {
+    loading = false;
+    error: string | null = null;
+    snapshot: ListenersSnapshot | null = null;
+    expandedUserIds = new Set<number | string>();
+    private pollTimer: ReturnType<typeof setInterval> | null = null;
+    private destroyed = false;
+
+    constructor(
+        private adminService: RdioScannerAdminService,
+        private cdr: ChangeDetectorRef,
+    ) {}
+
+    ngOnInit(): void {
+        void this.refresh(true);
+        this.pollTimer = setInterval(() => {
+            void this.refresh(false);
+        }, 5000);
+    }
+
+    ngOnDestroy(): void {
+        this.destroyed = true;
+        if (this.pollTimer) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+        }
+    }
+
+    async refresh(showSpinner: boolean = true): Promise<void> {
+        if (showSpinner) {
+            this.loading = true;
+            this.error = null;
+        }
+        try {
+            const snapshot = await this.adminService.getListeners();
+            if (this.destroyed) {
+                return;
+            }
+            this.snapshot = snapshot;
+            this.error = null;
+        } catch (err: any) {
+            if (this.destroyed) {
+                return;
+            }
+            this.error = err?.message || 'Failed to load listeners';
+        } finally {
+            if (!this.destroyed) {
+                this.loading = false;
+                this.cdr.detectChanges();
+            }
+        }
+    }
+
+    trackUser(_: number, user: ListenerUserSnapshot): string | number {
+        return user.anonymous ? 'anonymous' : user.userId;
+    }
+
+    displayName(user: ListenerUserSnapshot): string {
+        if (user.anonymous) {
+            return 'Anonymous';
+        }
+        const name = `${user.firstName || ''} ${user.lastName || ''}`.trim();
+        return name || user.email || `User #${user.userId}`;
+    }
+
+    expansionKey(user: ListenerUserSnapshot): string | number {
+        return user.anonymous ? 'anonymous' : user.userId;
+    }
+
+    isExpanded(user: ListenerUserSnapshot): boolean {
+        return this.expandedUserIds.has(this.expansionKey(user));
+    }
+
+    toggleExpanded(user: ListenerUserSnapshot): void {
+        const key = this.expansionKey(user);
+        if (this.expandedUserIds.has(key)) {
+            this.expandedUserIds.delete(key);
+        } else {
+            this.expandedUserIds.add(key);
+        }
+    }
+
+    kindLabel(kind: string): string {
+        return kind === 'mobile' ? 'Mobile' : 'Web';
+    }
+
+    connectedDuration(iso: string): string {
+        if (!iso) {
+            return '—';
+        }
+        const connectedAt = new Date(iso).getTime();
+        if (Number.isNaN(connectedAt)) {
+            return '—';
+        }
+        const seconds = Math.max(0, Math.floor((Date.now() - connectedAt) / 1000));
+        if (seconds < 60) {
+            return `${seconds}s`;
+        }
+        const minutes = Math.floor(seconds / 60);
+        if (minutes < 60) {
+            return `${minutes}m`;
+        }
+        const hours = Math.floor(minutes / 60);
+        const remMin = minutes % 60;
+        if (hours < 48) {
+            return remMin ? `${hours}h ${remMin}m` : `${hours}h`;
+        }
+        const days = Math.floor(hours / 24);
+        return `${days}d`;
+    }
+}

--- a/server/admin.go
+++ b/server/admin.go
@@ -224,6 +224,33 @@ func (admin *Admin) AlertsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (admin *Admin) ListenersHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		t := admin.GetAuthorization(r)
+		if !admin.ValidateToken(t) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		snapshot := ListenersSnapshot{}
+		if admin.Controller != nil && admin.Controller.Clients != nil {
+			snapshot = admin.Controller.Clients.SnapshotListeners()
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(snapshot); err != nil {
+			w.WriteHeader(http.StatusExpectationFailed)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "failed to marshal listeners snapshot",
+			})
+		}
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
 func (admin *Admin) SystemHealthHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:

--- a/server/client.go
+++ b/server/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +50,8 @@ type Client struct {
 	SystemsMap  SystemsMap
 	request     *http.Request
 	FCMToken    string // Set via the "FCM" WS command; links this session to a push token.
+	// ConnectedAt is set when the client is registered in Clients.Map.
+	ConnectedAt time.Time
 
 	// DownloadTimestamps tracks when each audio download was requested by this
 	// client, used for sliding-window rate limiting.
@@ -469,6 +472,9 @@ func (clients *Clients) Add(client *Client) {
 	clients.mutex.Lock()
 	defer clients.mutex.Unlock()
 
+	if client != nil && client.ConnectedAt.IsZero() {
+		client.ConnectedAt = time.Now().UTC()
+	}
 	clients.Map[client] = true
 }
 
@@ -582,6 +588,141 @@ func (clients *Clients) EmitListenersCount() {
 
 	for c := range clients.Map {
 		c.SendListenersCount(count)
+	}
+}
+
+// ListenerDeviceSnapshot is one live WebSocket session for the admin roster.
+type ListenerDeviceSnapshot struct {
+	IP             string    `json:"ip"`
+	ClientKind     string    `json:"clientKind"` // "web" | "mobile"
+	LivefeedActive bool      `json:"livefeedActive"`
+	ConnectedAt    time.Time `json:"connectedAt"`
+	PinExpired     bool      `json:"pinExpired"`
+}
+
+// ListenerUserSnapshot groups one user's live sessions (or anonymous sockets).
+type ListenerUserSnapshot struct {
+	UserId      uint64                   `json:"userId"`
+	Email       string                   `json:"email"`
+	FirstName   string                   `json:"firstName"`
+	LastName    string                   `json:"lastName"`
+	Anonymous   bool                     `json:"anonymous,omitempty"`
+	DeviceCount int                      `json:"deviceCount"`
+	Devices     []ListenerDeviceSnapshot `json:"devices"`
+}
+
+// ListenersSnapshot is the admin-facing live listeners roster.
+type ListenersSnapshot struct {
+	TotalConnections     int                    `json:"totalConnections"`
+	UniqueUsers          int                    `json:"uniqueUsers"`
+	AnonymousConnections int                    `json:"anonymousConnections"`
+	Listeners            []ListenerUserSnapshot `json:"listeners"`
+}
+
+// SnapshotListeners builds a grouped roster of live WebSocket clients.
+// PIN and FCM tokens are never included.
+func (clients *Clients) SnapshotListeners() ListenersSnapshot {
+	clients.mutex.Lock()
+	defer clients.mutex.Unlock()
+
+	type group struct {
+		user    *User
+		anon    bool
+		devices []ListenerDeviceSnapshot
+	}
+
+	byUser := map[uint64]*group{}
+	var anonGroup *group
+	total := 0
+	anonCount := 0
+
+	for c := range clients.Map {
+		if c == nil {
+			continue
+		}
+		total++
+
+		ip := ""
+		if c.request != nil {
+			ip = GetRemoteAddr(c.request)
+		}
+		kind := "web"
+		if c.FCMToken != "" {
+			kind = "mobile"
+		}
+		live := c.Livefeed != nil && !c.Livefeed.IsAllOff()
+		connectedAt := c.ConnectedAt
+		if connectedAt.IsZero() {
+			connectedAt = time.Now().UTC()
+		}
+		dev := ListenerDeviceSnapshot{
+			IP:             ip,
+			ClientKind:     kind,
+			LivefeedActive: live,
+			ConnectedAt:    connectedAt.UTC(),
+			PinExpired:     c.PinExpired,
+		}
+
+		if c.User != nil && c.User.Id > 0 {
+			g := byUser[c.User.Id]
+			if g == nil {
+				g = &group{user: c.User}
+				byUser[c.User.Id] = g
+			}
+			g.devices = append(g.devices, dev)
+			continue
+		}
+
+		anonCount++
+		if anonGroup == nil {
+			anonGroup = &group{anon: true}
+		}
+		anonGroup.devices = append(anonGroup.devices, dev)
+	}
+
+	sortDevices := func(devs []ListenerDeviceSnapshot) {
+		sort.Slice(devs, func(i, j int) bool {
+			return devs[i].ConnectedAt.After(devs[j].ConnectedAt)
+		})
+	}
+
+	listeners := make([]ListenerUserSnapshot, 0, len(byUser)+1)
+	for _, g := range byUser {
+		sortDevices(g.devices)
+		u := g.user
+		listeners = append(listeners, ListenerUserSnapshot{
+			UserId:      u.Id,
+			Email:       u.Email,
+			FirstName:   u.FirstName,
+			LastName:    u.LastName,
+			DeviceCount: len(g.devices),
+			Devices:     g.devices,
+		})
+	}
+
+	sort.Slice(listeners, func(i, j int) bool {
+		ai := strings.ToLower(strings.TrimSpace(listeners[i].LastName + " " + listeners[i].FirstName + " " + listeners[i].Email))
+		aj := strings.ToLower(strings.TrimSpace(listeners[j].LastName + " " + listeners[j].FirstName + " " + listeners[j].Email))
+		if ai == aj {
+			return listeners[i].UserId < listeners[j].UserId
+		}
+		return ai < aj
+	})
+
+	if anonGroup != nil && len(anonGroup.devices) > 0 {
+		sortDevices(anonGroup.devices)
+		listeners = append(listeners, ListenerUserSnapshot{
+			Anonymous:   true,
+			DeviceCount: len(anonGroup.devices),
+			Devices:     anonGroup.devices,
+		})
+	}
+
+	return ListenersSnapshot{
+		TotalConnections:     total,
+		UniqueUsers:          len(byUser),
+		AnonymousConnections: anonCount,
+		Listeners:            listeners,
 	}
 }
 

--- a/server/listeners_snapshot_test.go
+++ b/server/listeners_snapshot_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestSnapshotListenersGroupsDevices(t *testing.T) {
+	clients := NewClients()
+
+	userA := &User{Id: 10, Email: "a@example.com", FirstName: "Ann", LastName: "Alpha"}
+	userB := &User{Id: 20, Email: "b@example.com", FirstName: "Bob", LastName: "Beta"}
+
+	reqA := &http.Request{RemoteAddr: "10.0.0.1:1234", Header: http.Header{}}
+	reqB := &http.Request{RemoteAddr: "10.0.0.2:1234", Header: http.Header{}}
+	reqAnon := &http.Request{RemoteAddr: "10.0.0.3:1234", Header: http.Header{}}
+
+	c1 := &Client{User: userA, request: reqA, Livefeed: NewLivefeed(), ConnectedAt: time.Now().UTC().Add(-2 * time.Minute)}
+	c2 := &Client{User: userA, request: reqB, FCMToken: "token-abc", Livefeed: NewLivefeed(), ConnectedAt: time.Now().UTC().Add(-1 * time.Minute)}
+	c3 := &Client{User: userB, request: reqB, Livefeed: NewLivefeed(), ConnectedAt: time.Now().UTC()}
+	c4 := &Client{request: reqAnon, Livefeed: NewLivefeed(), ConnectedAt: time.Now().UTC()}
+
+	clients.Add(c1)
+	clients.Add(c2)
+	clients.Add(c3)
+	clients.Add(c4)
+
+	snap := clients.SnapshotListeners()
+	if snap.TotalConnections != 4 {
+		t.Fatalf("totalConnections=%d want 4", snap.TotalConnections)
+	}
+	if snap.UniqueUsers != 2 {
+		t.Fatalf("uniqueUsers=%d want 2", snap.UniqueUsers)
+	}
+	if snap.AnonymousConnections != 1 {
+		t.Fatalf("anonymousConnections=%d want 1", snap.AnonymousConnections)
+	}
+	if len(snap.Listeners) != 3 {
+		t.Fatalf("listeners=%d want 3 (2 users + anonymous)", len(snap.Listeners))
+	}
+
+	var foundA, foundB, foundAnon bool
+	for _, u := range snap.Listeners {
+		if u.Anonymous {
+			foundAnon = true
+			if u.DeviceCount != 1 {
+				t.Fatalf("anonymous deviceCount=%d want 1", u.DeviceCount)
+			}
+			continue
+		}
+		if u.UserId == 10 {
+			foundA = true
+			if u.DeviceCount != 2 {
+				t.Fatalf("user A deviceCount=%d want 2", u.DeviceCount)
+			}
+			if u.Email != "a@example.com" {
+				t.Fatalf("user A email=%q", u.Email)
+			}
+			kinds := map[string]bool{}
+			for _, d := range u.Devices {
+				kinds[d.ClientKind] = true
+				if d.IP == "" {
+					t.Fatal("expected IP on device")
+				}
+			}
+			if !kinds["web"] || !kinds["mobile"] {
+				t.Fatalf("user A kinds=%v want web+mobile", kinds)
+			}
+		}
+		if u.UserId == 20 {
+			foundB = true
+			if u.DeviceCount != 1 {
+				t.Fatalf("user B deviceCount=%d want 1", u.DeviceCount)
+			}
+		}
+		// Ensure secrets are not accidentally present via JSON field names on structs
+		// (PIN/FCM are simply not on the snapshot types).
+	}
+	if !foundA || !foundB || !foundAnon {
+		t.Fatalf("missing groups: A=%v B=%v anon=%v", foundA, foundB, foundAnon)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -329,6 +329,8 @@ func main() {
 
 	http.HandleFunc("/api/admin/alerts", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.AlertsHandler)).ServeHTTP)
 
+	http.HandleFunc("/api/admin/listeners", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.ListenersHandler)).ServeHTTP)
+
 	http.HandleFunc("/api/admin/systemhealth", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.SystemHealthHandler)).ServeHTTP)
 
 	http.HandleFunc("/api/admin/system-no-audio-settings", wrapHandler(controller.Admin.requireLocalhost(controller.Admin.SystemNoAudioSettingsHandler)).ServeHTTP)


### PR DESCRIPTION
## Summary
- Adds admin-only `GET /api/admin/listeners` that snapshots live WebSocket sessions grouped by user (anonymous sockets in one bucket), including multi-device counts, IP, web/mobile kind, livefeed state, and connect time. PIN and FCM tokens are not returned.
- New Operations → **Listeners** panel with 5s auto-refresh, summary counts, expandable per-user rows, and clear `N devices` badges.
- Admin Users status shows a **Listening** / **Listening · N devices** chip for online accounts.

Made with [Cursor](https://cursor.com)