### PR TITLE
Add multi-talkgroup playback filters and duration column

### DIFF
--- a/client/src/app/components/rdio-scanner/rdio-scanner.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.ts
@@ -66,6 +66,8 @@ export interface RdioScannerCall {
         siteRef: number;
         systemId: number;
     };
+    /** Audio length in seconds from playback search; 0/missing means unknown. */
+    duration?: number;
     hasTones?: boolean;
     toneSequence?: RdioScannerToneSequence;
     transcript?: string;
@@ -345,6 +347,8 @@ export interface RdioScannerSearchOptions {
     system?: number;
     tag?: string;
     talkgroup?: number;
+    /** Multiple talkgroup refs (same system). Preferred when 2+ are selected. */
+    talkgroups?: number[];
     unit?: number;
 }
 

--- a/client/src/app/components/rdio-scanner/search/search.component.html
+++ b/client/src/app/components/rdio-scanner/search/search.component.html
@@ -87,12 +87,14 @@
           <mat-icon>group</mat-icon>
           <span>{{ getSelectedTalkgroupLabel() }}</span>
         </button>
-        <mat-menu #talkgroupMenu="matMenu" class="tlr-lcd-menu">
-          <button mat-menu-item (click)="setTalkgroup(-1)">
+        <mat-menu #talkgroupMenu="matMenu" class="tlr-lcd-menu talkgroup-multi-menu">
+          <button type="button" mat-menu-item (click)="$event.stopPropagation(); clearTalkgroups()">
+            <mat-checkbox [checked]="getSelectedTalkgroups().length === 0" [disableRipple]="true"></mat-checkbox>
             <span>All Talkgroups</span>
           </button>
           @for (talkgroup of optionsTalkgroup; track talkgroup; let i = $index) {
-            <button mat-menu-item (click)="setTalkgroup(i)">
+            <button type="button" mat-menu-item (click)="$event.stopPropagation(); toggleTalkgroup(i)">
+              <mat-checkbox [checked]="isTalkgroupSelected(i)" [disableRipple]="true"></mat-checkbox>
               <span>{{ talkgroup }}</span>
             </button>
           }
@@ -277,6 +279,14 @@
             </mat-header-cell>
             <mat-cell *matCellDef="let row">
               <span>{{ row?.talkgroupData?.name }}</span>
+            </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="duration">
+            <mat-header-cell *matHeaderCellDef>
+              <span>Duration</span>
+            </mat-header-cell>
+            <mat-cell *matCellDef="let row" class="archive-duration-cell">
+              <span>{{ formatCallDuration(row?.duration) }}</span>
             </mat-cell>
           </ng-container>
           <mat-header-row *matHeaderRowDef="archiveTableColumns; sticky: true">

--- a/client/src/app/components/rdio-scanner/search/search.component.scss
+++ b/client/src/app/components/rdio-scanner/search/search.component.scss
@@ -1122,6 +1122,17 @@ input[matInput][style*='opacity: 0'] {
         font-size: inherit;
       }
     }
+
+    .archive-duration-cell {
+      font-family: var(--tlr-font-numeric, monospace);
+      font-variant-numeric: tabular-nums;
+      justify-content: flex-end;
+      min-width: 3.5rem;
+
+      > span {
+        font-family: inherit;
+      }
+    }
   }
 
   /* Pretty up paginator chrome inside the LCD bezel. */

--- a/client/src/app/components/rdio-scanner/search/search.component.ts
+++ b/client/src/app/components/rdio-scanner/search/search.component.ts
@@ -47,6 +47,8 @@ import { TagColorService } from '../tag-color.service';
 interface PlaybackPrefs {
     systemLabel?: string;
     talkgroupLabel?: string;
+    /** Multi-select talkgroup labels (same system). */
+    talkgroupLabels?: string[];
     groupLabel?: string;
     tagLabel?: string;
     favoriteKey?: string;
@@ -78,6 +80,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         'tgid',
         'source',
         'name',
+        'duration',
     ];
     private readonly archiveColumnsAdmin = [
         'control',
@@ -89,6 +92,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         'tgid',
         'source',
         'name',
+        'duration',
     ];
 
     get archiveTableColumns(): string[] {
@@ -121,7 +125,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             sort: this.pendingPrefs?.sort ?? -1,
             system: [-1],
             tag: [-1],
-            talkgroup: [-1],
+            talkgroups: [[] as number[]],
             favorite: [-1],
         });
 
@@ -407,7 +411,9 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         const selectedGroup = this.getSelectedGroup();
         const selectedSystem = this.getSelectedSystem();
         const selectedTag = this.getSelectedTag();
-        const selectedTalkgroup = this.getSelectedTalkgroup();
+        const selectedTalkgroups = this.getSelectedTalkgroups();
+        const selectedTalkgroup = selectedTalkgroups.length === 1 ? selectedTalkgroups[0] : undefined;
+        const selectedTalkgroupLabels = selectedTalkgroups.map((tg) => tg.label);
 
         this.optionsSystem = this.config.systems
             .filter((system) => {
@@ -461,12 +467,17 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             })
             .sort((a, b) => a.localeCompare(b))
 
+        // Remap selected talkgroup indexes after options rebuild.
+        const remappedTalkgroups = selectedTalkgroupLabels
+            .map((label) => this.optionsTalkgroup.findIndex((tg) => tg === label))
+            .filter((idx) => idx >= 0);
+
         // Patch form values WITHOUT emitting events to prevent triggering formChangeHandler
         this.form.patchValue({
             group: selectedGroup ? this.optionsGroup.findIndex((group) => group === selectedGroup) : -1,
             system: selectedSystem ? this.optionsSystem.findIndex((system) => system === selectedSystem.label) : -1,
             tag: selectedTag ? this.optionsTag.findIndex((tag) => tag === selectedTag) : -1,
-            talkgroup: selectedTalkgroup ? this.optionsTalkgroup.findIndex((talkgroup) => talkgroup === selectedTalkgroup.label) : -1,
+            talkgroups: remappedTalkgroups,
         }, { emitEvent: false });
     }
 
@@ -571,6 +582,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         const normalizedOptions: any = {
             system: options.system,
             talkgroup: options.talkgroup,
+            talkgroups: options.talkgroups,
             date: options.date ? (options.date instanceof Date ? options.date.toISOString() : options.date) : undefined,
             limit: options.limit,
             offset: options.offset,
@@ -589,7 +601,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             sort: -1,
             system: -1,
             tag: -1,
-            talkgroup: -1,
+            talkgroups: [],
             favorite: -1,
         });
 
@@ -602,6 +614,9 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
     setFavorite(value: number): void {
         this.form.get('favorite')?.setValue(value, { emitEvent: false });
+        if (value >= 0) {
+            this.form.get('talkgroups')?.setValue([], { emitEvent: false });
+        }
         this.savePrefs();
         this.formChangeHandler();
     }
@@ -737,14 +752,45 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
     setSystem(value: number): void {
         this.form.get('system')?.setValue(value, { emitEvent: false });
+        this.form.get('talkgroups')?.setValue([], { emitEvent: false });
+        this.form.get('favorite')?.setValue(-1, { emitEvent: false });
         this.savePrefs();
         this.formChangeHandler();
     }
 
-    setTalkgroup(value: number): void {
-        this.form.get('talkgroup')?.setValue(value, { emitEvent: false });
+    clearTalkgroups(): void {
+        this.form.get('talkgroups')?.setValue([], { emitEvent: false });
+        this.form.get('favorite')?.setValue(-1, { emitEvent: false });
         this.savePrefs();
         this.formChangeHandler();
+    }
+
+    toggleTalkgroup(index: number): void {
+        if (index < 0) {
+            this.clearTalkgroups();
+            return;
+        }
+        const current: number[] = Array.isArray(this.form.value.talkgroups)
+            ? [...this.form.value.talkgroups]
+            : [];
+        const pos = current.indexOf(index);
+        if (pos >= 0) {
+            current.splice(pos, 1);
+        } else {
+            current.push(index);
+            current.sort((a, b) => a - b);
+        }
+        this.form.get('talkgroups')?.setValue(current, { emitEvent: false });
+        this.form.get('favorite')?.setValue(-1, { emitEvent: false });
+        this.savePrefs();
+        this.formChangeHandler();
+    }
+
+    isTalkgroupSelected(index: number): boolean {
+        const current: number[] = Array.isArray(this.form.value.talkgroups)
+            ? this.form.value.talkgroups
+            : [];
+        return current.includes(index);
     }
 
     setGroup(value: number): void {
@@ -766,9 +812,10 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
     }
 
     getSelectedTalkgroupLabel(): string {
-        const index = this.form.value.talkgroup;
-        if (index == null || index < 0) return 'All Talkgroups';
-        return this.optionsTalkgroup[index] || 'All Talkgroups';
+        const selected = this.getSelectedTalkgroups();
+        if (selected.length === 0) return 'All Talkgroups';
+        if (selected.length === 1) return selected[0].label;
+        return `${selected.length} talkgroups`;
     }
 
     getSelectedGroupLabel(): string {
@@ -836,11 +883,11 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             }
         }
 
-        if ((this.form.value.talkgroup ?? -1) >= 0) {
-            const talkgroup = this.getSelectedTalkgroup();
-            if (talkgroup) {
-                options.talkgroup = talkgroup.id;
-            }
+        const selectedTalkgroups = this.getSelectedTalkgroups();
+        if (selectedTalkgroups.length === 1) {
+            options.talkgroup = selectedTalkgroups[0].id;
+        } else if (selectedTalkgroups.length > 1) {
+            options.talkgroups = selectedTalkgroups.map((tg) => tg.id);
         }
 
         if ((this.form.value.favorite ?? -1) >= 0) {
@@ -848,6 +895,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             if (favorite) {
                 options.system = favorite.systemId;
                 options.talkgroup = favorite.talkgroupId;
+                delete options.talkgroups;
             }
         }
 
@@ -857,6 +905,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             system: options.system,
             tag: options.tag,
             talkgroup: options.talkgroup,
+            talkgroups: options.talkgroups,
             sort: options.sort,
         };
         const lastFilters = this.lastSearchOptions ? {
@@ -865,6 +914,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             system: this.lastSearchOptions.system,
             tag: this.lastSearchOptions.tag,
             talkgroup: this.lastSearchOptions.talkgroup,
+            talkgroups: this.lastSearchOptions.talkgroups,
             sort: this.lastSearchOptions.sort,
         } : null;
         const optionsChanged = !lastFilters || JSON.stringify(currentFilters) !== JSON.stringify(lastFilters);
@@ -892,6 +942,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         const normalizedOptions: any = {
             system: options.system,
             talkgroup: options.talkgroup,
+            talkgroups: options.talkgroups,
             date: options.date ? (options.date instanceof Date ? options.date.toISOString() : options.date) : undefined,
             limit: options.limit,
             offset: options.offset,
@@ -1066,12 +1117,43 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         return tagIndex != null && tagIndex >= 0 ? this.optionsTag[tagIndex] : undefined;
     }
 
-    private getSelectedTalkgroup(): RdioScannerTalkgroup | undefined {
+    getSelectedTalkgroups(): RdioScannerTalkgroup[] {
         const system = this.getSelectedSystem();
-        if (!system) return undefined;
-        const talkgroupIndex = this.form.value.talkgroup;
-        if (talkgroupIndex == null || talkgroupIndex < 0) return undefined;
-        return system.talkgroups.find((talkgroup) => talkgroup.label === this.optionsTalkgroup[talkgroupIndex]);
+        if (!system) return [];
+        const indexes: number[] = Array.isArray(this.form.value.talkgroups)
+            ? this.form.value.talkgroups
+            : [];
+        const out: RdioScannerTalkgroup[] = [];
+        for (const talkgroupIndex of indexes) {
+            if (talkgroupIndex == null || talkgroupIndex < 0) continue;
+            const label = this.optionsTalkgroup[talkgroupIndex];
+            if (!label) continue;
+            const talkgroup = system.talkgroups.find((tg) => tg.label === label);
+            if (talkgroup) {
+                out.push(talkgroup);
+            }
+        }
+        return out;
+    }
+
+    private getSelectedTalkgroup(): RdioScannerTalkgroup | undefined {
+        const selected = this.getSelectedTalkgroups();
+        return selected.length === 1 ? selected[0] : undefined;
+    }
+
+    /** Format playback row duration; em dash when missing/zero. */
+    formatCallDuration(seconds?: number | null): string {
+        if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) {
+            return '—';
+        }
+        const total = Math.round(seconds);
+        const hours = Math.floor(total / 3600);
+        const minutes = Math.floor((total % 3600) / 60);
+        const secs = total % 60;
+        if (hours > 0) {
+            return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+        }
+        return `${minutes}:${String(secs).padStart(2, '0')}`;
     }
 
     // ── Issue #185: persistence ────────────────────────────────────────────────
@@ -1093,7 +1175,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         try {
             if (typeof localStorage === 'undefined') return;
             const system = this.getSelectedSystem();
-            const talkgroup = this.getSelectedTalkgroup();
+            const talkgroups = this.getSelectedTalkgroups();
             const group = this.getSelectedGroup();
             const tag = this.getSelectedTag();
             const favIdx = this.form.value.favorite ?? -1;
@@ -1101,7 +1183,8 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
             const prefs: PlaybackPrefs = {
                 systemLabel: system?.label,
-                talkgroupLabel: talkgroup?.label,
+                talkgroupLabel: talkgroups.length === 1 ? talkgroups[0].label : undefined,
+                talkgroupLabels: talkgroups.map((tg) => tg.label),
                 groupLabel: group,
                 tagLabel: tag,
                 favoriteKey: fav ? `${fav.systemId}:${fav.talkgroupId}` : undefined,
@@ -1145,11 +1228,14 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             this.refreshFilters();
         }
 
-        if (prefs.talkgroupLabel) {
-            const idx = this.optionsTalkgroup.findIndex((label) => label === prefs.talkgroupLabel);
-            if (idx >= 0) {
-                this.form.get('talkgroup')?.setValue(idx, { emitEvent: false });
-            }
+        const savedTalkgroupLabels = (prefs.talkgroupLabels && prefs.talkgroupLabels.length > 0)
+            ? prefs.talkgroupLabels
+            : (prefs.talkgroupLabel ? [prefs.talkgroupLabel] : []);
+        if (savedTalkgroupLabels.length > 0) {
+            const indexes = savedTalkgroupLabels
+                .map((label) => this.optionsTalkgroup.findIndex((tg) => tg === label))
+                .filter((idx) => idx >= 0);
+            this.form.get('talkgroups')?.setValue(indexes, { emitEvent: false });
         }
 
         if (prefs.favoriteKey) {
@@ -1159,9 +1245,12 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
         // After config-dependent restoration is in place, kick a search so the
         // table populates without requiring the user to click anything.
+        const restoredTalkgroups: number[] = Array.isArray(this.form.value.talkgroups)
+            ? this.form.value.talkgroups
+            : [];
         if (
             patch['system'] !== undefined ||
-            this.form.value.talkgroup >= 0 ||
+            restoredTalkgroups.length > 0 ||
             this.form.value.favorite >= 0 ||
             this.selectedDate
         ) {

--- a/server/call.go
+++ b/server/call.go
@@ -1055,9 +1055,18 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 		conditions := []string{
 			fmt.Sprintf(`c."systemRef" = %d`, v),
 		}
-		switch v := searchOptions.Talkgroup.(type) {
-		case uint:
-			conditions = append(conditions, fmt.Sprintf(`c."talkgroupRef" = %d`, v))
+		tgRefs := searchOptions.resolvedTalkgroupRefs()
+		switch len(tgRefs) {
+		case 0:
+			// All talkgroups on this system
+		case 1:
+			conditions = append(conditions, fmt.Sprintf(`c."talkgroupRef" = %d`, tgRefs[0]))
+		default:
+			parts := make([]string, len(tgRefs))
+			for i, id := range tgRefs {
+				parts[i] = fmt.Sprintf("%d", id)
+			}
+			conditions = append(conditions, fmt.Sprintf(`c."talkgroupRef" IN (%s)`, strings.Join(parts, ", ")))
 		}
 		if len(conditions) > 0 {
 			where = append(where, fmt.Sprintf("(%s)", strings.Join(conditions, " AND ")))
@@ -1182,7 +1191,7 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 	searchResults.HasMore = false
 
 	queryLimit := limit + 1
-	baseSelect := fmt.Sprintf(`SELECT c."callId", c."timestamp", c."systemRef", c."talkgroupRef", c."frequency", c."siteRef", (SELECT cu."unitRef" FROM "callUnits" cu WHERE cu."callId" = c."callId" ORDER BY cu."offset" LIMIT 1) as "source" FROM "calls" AS c LEFT JOIN "delayed" AS d ON d."callId" = c."callId" %s ORDER BY c."timestamp" %s`, delayWhere, order)
+	baseSelect := fmt.Sprintf(`SELECT c."callId", c."timestamp", c."systemRef", c."talkgroupRef", c."frequency", c."siteRef", (SELECT cu."unitRef" FROM "callUnits" cu WHERE cu."callId" = c."callId" ORDER BY cu."offset" LIMIT 1) as "source", c."audioDuration" FROM "calls" AS c LEFT JOIN "delayed" AS d ON d."callId" = c."callId" %s ORDER BY c."timestamp" %s`, delayWhere, order)
 
 	enforcePlaybackACL := calls.controller.requiresUserAuth() && !client.BypassPlaybackSearchACL
 
@@ -1208,7 +1217,8 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 			var frequency sql.NullInt64
 			var siteRef sql.NullInt64
 			var source sql.NullInt64
-			if err = rows.Scan(&searchResult.Id, &timestamp, &searchResult.System, &searchResult.Talkgroup, &frequency, &siteRef, &source); err != nil {
+			var audioDuration sql.NullFloat64
+			if err = rows.Scan(&searchResult.Id, &timestamp, &searchResult.System, &searchResult.Talkgroup, &frequency, &siteRef, &source, &audioDuration); err != nil {
 				break
 			}
 
@@ -1226,6 +1236,9 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 			}
 			if source.Valid && source.Int64 > 0 {
 				searchResult.Source = uint(source.Int64)
+			}
+			if audioDuration.Valid && audioDuration.Float64 > 0 {
+				searchResult.Duration = audioDuration.Float64
 			}
 			totalCalls++
 
@@ -1266,7 +1279,8 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 			var frequency sql.NullInt64
 			var siteRef sql.NullInt64
 			var source sql.NullInt64
-			if err = chunkRows.Scan(&searchResult.Id, &timestamp, &searchResult.System, &searchResult.Talkgroup, &frequency, &siteRef, &source); err != nil {
+			var audioDuration sql.NullFloat64
+			if err = chunkRows.Scan(&searchResult.Id, &timestamp, &searchResult.System, &searchResult.Talkgroup, &frequency, &siteRef, &source, &audioDuration); err != nil {
 				break
 			}
 
@@ -1284,6 +1298,9 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 			}
 			if source.Valid && source.Int64 > 0 {
 				searchResult.Source = uint(source.Int64)
+			}
+			if audioDuration.Valid && audioDuration.Float64 > 0 {
+				searchResult.Duration = audioDuration.Float64
 			}
 
 			if !calls.playbackSearchRowPlayableNow(client, searchResult) {
@@ -1463,18 +1480,44 @@ func (calls *Calls) writeCall(call *Call, db *Database) (uint64, error) {
 }
 
 type CallsSearchOptions struct {
-	Date      any `json:"date,omitempty"`
-	Group     any `json:"group,omitempty"`
-	Limit     any `json:"limit,omitempty"`
-	Offset    any `json:"offset,omitempty"`
-	Sort      any `json:"sort,omitempty"`
-	System    any `json:"system,omitempty"`
-	Tag       any `json:"tag,omitempty"`
-	Talkgroup any `json:"talkgroup,omitempty"`
+	Date       any    `json:"date,omitempty"`
+	Group      any    `json:"group,omitempty"`
+	Limit      any    `json:"limit,omitempty"`
+	Offset     any    `json:"offset,omitempty"`
+	Sort       any    `json:"sort,omitempty"`
+	System     any    `json:"system,omitempty"`
+	Tag        any    `json:"tag,omitempty"`
+	Talkgroup  any    `json:"talkgroup,omitempty"`
+	Talkgroups []uint `json:"talkgroups,omitempty"`
 }
 
 func NewCallSearchOptions() *CallsSearchOptions {
 	return &CallsSearchOptions{}
+}
+
+func (searchOptions *CallsSearchOptions) resolvedTalkgroupRefs() []uint {
+	if searchOptions == nil {
+		return nil
+	}
+	if len(searchOptions.Talkgroups) > 0 {
+		seen := map[uint]bool{}
+		out := make([]uint, 0, len(searchOptions.Talkgroups))
+		for _, id := range searchOptions.Talkgroups {
+			if id == 0 || seen[id] {
+				continue
+			}
+			seen[id] = true
+			out = append(out, id)
+		}
+		return out
+	}
+	switch v := searchOptions.Talkgroup.(type) {
+	case uint:
+		if v > 0 {
+			return []uint{v}
+		}
+	}
+	return nil
 }
 
 func (searchOptions *CallsSearchOptions) fromMap(m map[string]any) *CallsSearchOptions {
@@ -1515,9 +1558,37 @@ func (searchOptions *CallsSearchOptions) fromMap(m map[string]any) *CallsSearchO
 		searchOptions.Tag = v
 	}
 
+	parseTalkgroupList := func(items []any) []uint {
+		out := make([]uint, 0, len(items))
+		seen := map[uint]bool{}
+		for _, item := range items {
+			n, ok := item.(float64)
+			if !ok || n <= 0 {
+				continue
+			}
+			id := uint(n)
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			out = append(out, id)
+		}
+		return out
+	}
+
+	switch v := m["talkgroups"].(type) {
+	case []any:
+		searchOptions.Talkgroups = parseTalkgroupList(v)
+	}
+
 	switch v := m["talkgroup"].(type) {
 	case float64:
 		searchOptions.Talkgroup = uint(v)
+	case []any:
+		// Back-compat: allow talkgroup as an array too.
+		if len(searchOptions.Talkgroups) == 0 {
+			searchOptions.Talkgroups = parseTalkgroupList(v)
+		}
 	}
 
 	return searchOptions
@@ -1531,6 +1602,7 @@ type CallsSearchResult struct {
 	Frequency uint      `json:"frequency,omitempty"`
 	Source    uint      `json:"source,omitempty"`
 	Site      uint      `json:"site,omitempty"`
+	Duration  float64   `json:"duration,omitempty"`
 }
 
 type CallsSearchResults struct {

--- a/server/call_search_talkgroups_test.go
+++ b/server/call_search_talkgroups_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCallsSearchOptionsResolvedTalkgroups(t *testing.T) {
+	o := NewCallSearchOptions()
+	if refs := o.resolvedTalkgroupRefs(); len(refs) != 0 {
+		t.Fatalf("empty options refs=%v", refs)
+	}
+
+	o.Talkgroup = uint(12)
+	if refs := o.resolvedTalkgroupRefs(); len(refs) != 1 || refs[0] != 12 {
+		t.Fatalf("scalar talkgroup refs=%v", refs)
+	}
+
+	o.Talkgroups = []uint{7, 9, 7, 0}
+	if refs := o.resolvedTalkgroupRefs(); len(refs) != 2 || refs[0] != 7 || refs[1] != 9 {
+		t.Fatalf("talkgroups array prefers list and dedupes, got %v", refs)
+	}
+
+	from := NewCallSearchOptions().fromMap(map[string]any{
+		"system":     float64(100),
+		"talkgroups": []any{float64(3), float64(5), float64(3)},
+	})
+	if _, ok := from.System.(uint); !ok {
+		t.Fatalf("system not parsed")
+	}
+	refs := from.resolvedTalkgroupRefs()
+	if len(refs) != 2 || refs[0] != 3 || refs[1] != 5 {
+		t.Fatalf("fromMap talkgroups=%v", refs)
+	}
+}


### PR DESCRIPTION
## Summary
- Playback (Archive) talkgroup filter supports multi-select within a system so related channels (e.g. PD + EMS) can be reviewed in one stream. Empty selection still means all talkgroups on that system.
- Search accepts `talkgroups[]` server-side (`talkgroupRef IN (...)`) while keeping scalar `talkgroup` for back-compat and favorites.
- Archive results include a **Duration** column from `audioDuration` (`m:ss` / `—` when unknown).

Closes discussion https://github.com/Thinline-Dynamic-Solutions/ThinLineRadio/discussions/274