### PR TITLE
Honor per-system Auto Populate for talkgroups

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/config/options/options.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/options/options.component.html
@@ -1261,7 +1261,7 @@
         <div class="row">
           <p>
             <span class="mat-body">Auto Populate</span><br>
-            <span class="mat-caption">Globally allows the automatic creation of unconfigured systems and talkgroups.</span>
+            <span class="mat-caption">Allows automatic creation of unknown systems. Talkgroups on an existing system follow that system's Auto Populate switch.</span>
           </p>
           <div>
             <mat-slide-toggle color="primary" formControlName="autoPopulate"></mat-slide-toggle>

--- a/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/system/system.component.html
@@ -170,7 +170,7 @@
           <label class="field-label">Auto Populate</label>
           <mat-slide-toggle color="primary" formControlName="autoPopulate"></mat-slide-toggle>
         </div>
-        <span class="field-hint">Auto-create unconfigured talkgroups</span>
+        <span class="field-hint">Auto-create unconfigured talkgroups on this system. Global Auto Populate does not override this.</span>
       </div>
 
       @if (form.get('autoPopulate')?.value) {

--- a/server/controller.go
+++ b/server/controller.go
@@ -570,8 +570,11 @@ func (controller *Controller) IngestCall(call *Call) {
 		controller.Systems.List = append(controller.Systems.List, system)
 	}
 
-	if controller.Options.AutoPopulate || (system != nil && system.AutoPopulate) {
-		if system != nil && talkgroup == nil && talkgroupId > 0 {
+	// Per-system AutoPopulate is authoritative for talkgroups. Global AutoPopulate
+	// only creates unknown systems (above); it must not keep adding TGs after the
+	// system switch is turned off.
+	if system != nil && system.AutoPopulate {
+		if talkgroup == nil && talkgroupId > 0 {
 			populated = true
 
 			groupLabels := []string{"Unknown"}


### PR DESCRIPTION
## Summary
- Ingest used to auto-create talkgroups whenever **global** Auto Populate was on, so a system's Auto Populate switch had no effect.
- Talkgroups are now created only when that system's Auto Populate is on. Global Auto Populate still creates unknown systems only.
- Admin copy updated so the two switches match that behavior.

Made with [Cursor](https://cursor.com)