### PR TITLE
Tighten arrival-time duplicate detection (no hash/timestamp restore)

### DIFF
--- a/server/call.go
+++ b/server/call.go
@@ -560,7 +560,11 @@ func (calls *Calls) CheckDuplicateByReceivedAt(call *Call, db *Database) (bool, 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	windowStart := time.Now().Add(-receivedAtDuplicateWindow)
+	arrivedAt := time.Now()
+	if !call.ReceivedAt.IsZero() {
+		arrivedAt = call.ReceivedAt
+	}
+	windowStart := arrivedAt.Add(-receivedAtDuplicateWindow)
 
 	// Look for the most recent call on this system+talkgroup that arrived within
 	// the window. The duration guard prevents false positives from genuinely
@@ -571,7 +575,12 @@ func (calls *Calls) CheckDuplicateByReceivedAt(call *Call, db *Database) (bool, 
 	)
 
 	var priorDur sql.NullFloat64
-	_ = db.Sql.QueryRowContext(ctx, query, windowStart).Scan(&priorDur)
+	if err := db.Sql.QueryRowContext(ctx, query, windowStart).Scan(&priorDur); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
 
 	if !priorDur.Valid {
 		return false, nil

--- a/server/controller.go
+++ b/server/controller.go
@@ -847,8 +847,11 @@ func (controller *Controller) IngestCall(call *Call) {
 
 		// Pass 1: in-memory cache — catches simultaneous arrivals before either
 		// has been written to the database (closes the race window).
-		if !call.IsDuplicate && controller.DedupCache != nil {
-			if controller.DedupCache.CheckAndMarkReceivedAt(call.System.Id, call.Talkgroup.Id) {
+		if !call.IsDuplicate && controller.DedupCache != nil && call.System != nil && call.Talkgroup != nil {
+			if _, err := controller.getCallDuration(call); err != nil {
+				controller.Logs.LogEvent(LogLevelWarn, fmt.Sprintf("duplicate check: duration: %v", err))
+			}
+			if controller.DedupCache.CheckAndMarkReceivedAt(call.System.Id, call.Talkgroup.Id, call.Duration) {
 				logCall(call, LogLevelWarn, "duplicate (receivedAt cache)")
 				call.IsDuplicate = true
 			}

--- a/server/dedup_cache.go
+++ b/server/dedup_cache.go
@@ -24,9 +24,8 @@ import (
 // DedupEntry caches metadata for a recently seen call to catch simultaneous
 // duplicate arrivals before either has been written to the DB.
 type DedupEntry struct {
-	Duration      float64   // Audio duration in seconds (for ratio guard)
-	CallTimestamp int64     // P25 call timestamp in milliseconds
-	SeenAt        time.Time
+	Duration float64   // Audio duration in seconds (for similarity guard)
+	SeenAt   time.Time // First arrival time for this system+talkgroup key
 }
 
 // DedupCache is a mutex-protected in-memory cache that closes the race window
@@ -34,9 +33,7 @@ type DedupEntry struct {
 // before either has been written.
 //
 // Key prefixes:
-//   "ep:systemId:talkgroupId" — energy profile entry
-//   "ah:systemId:talkgroupId:hash" — PCM content hash entry
-//   "ts:systemId:talkgroupId" — timestamp fallback entry
+//   "ra:systemId:talkgroupId" — server arrival-time duplicate entry
 //
 // A background goroutine evicts stale entries every 30 seconds.
 type DedupCache struct {
@@ -60,25 +57,23 @@ func NewDedupCache(timeframeMs uint) *DedupCache {
 	return dc
 }
 
-
-// CheckAndMarkReceivedAt checks whether a call for the given system+talkgroup
-// was already seen within receivedAtDuplicateWindow (1 second) of now.
-// Returns true (duplicate) if so. Always records the current arrival time so
-// back-to-back simultaneous uploads are caught before either hits the database.
-func (dc *DedupCache) CheckAndMarkReceivedAt(systemId, talkgroupId uint64) bool {
+// CheckAndMarkReceivedAt returns true when a call for the given system+talkgroup
+// was already seen within receivedAtDuplicateWindow and the durations match.
+// SeenAt is not refreshed on a hit so a busy talkgroup cannot slide the window
+// forever and drop consecutive real traffic.
+func (dc *DedupCache) CheckAndMarkReceivedAt(systemId, talkgroupId uint64, duration float64) bool {
 	key := fmt.Sprintf("ra:%d:%d", systemId, talkgroupId)
 	now := time.Now()
 	dc.mutex.Lock()
 	defer dc.mutex.Unlock()
 
 	if entry, ok := dc.entries[key]; ok {
-		if now.Sub(entry.SeenAt) <= receivedAtDuplicateWindow {
-			// Update SeenAt so we keep blocking additional arrivals within the window.
-			entry.SeenAt = now
+		if now.Sub(entry.SeenAt) <= receivedAtDuplicateWindow &&
+			audioDurationsSimilarForReceivedAtDup(duration, entry.Duration) {
 			return true
 		}
 	}
-	dc.entries[key] = &DedupEntry{SeenAt: now}
+	dc.entries[key] = &DedupEntry{SeenAt: now, Duration: duration}
 	return false
 }
 

--- a/server/dedup_cache_test.go
+++ b/server/dedup_cache_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCheckAndMarkReceivedAtDoesNotSlideWindow(t *testing.T) {
+	dc := NewDedupCache(30000)
+	defer dc.Stop()
+
+	if dc.CheckAndMarkReceivedAt(1, 2, 2.0) {
+		t.Fatal("first call should not be a duplicate")
+	}
+
+	dc.mutex.Lock()
+	dc.entries["ra:1:2"].SeenAt = time.Now().Add(-900 * time.Millisecond)
+	dc.mutex.Unlock()
+
+	if !dc.CheckAndMarkReceivedAt(1, 2, 2.0) {
+		t.Fatal("second similar call within 1s should be a duplicate")
+	}
+
+	dc.mutex.Lock()
+	dc.entries["ra:1:2"].SeenAt = time.Now().Add(-1100 * time.Millisecond)
+	dc.mutex.Unlock()
+
+	if dc.CheckAndMarkReceivedAt(1, 2, 2.0) {
+		t.Fatal("call after the 1s window should not stay blocked by a sliding SeenAt")
+	}
+}
+
+func TestCheckAndMarkReceivedAtRequiresSimilarDuration(t *testing.T) {
+	dc := NewDedupCache(30000)
+	defer dc.Stop()
+
+	if dc.CheckAndMarkReceivedAt(1, 2, 0.5) {
+		t.Fatal("first call should not be a duplicate")
+	}
+	if dc.CheckAndMarkReceivedAt(1, 2, 8.0) {
+		t.Fatal("different-length call on a busy talkgroup should not be treated as a duplicate")
+	}
+}


### PR DESCRIPTION
## Summary
- Keeps **arrival-time-only** duplicate detection (no PCM hash, no radio timestamp restore).
- In-memory `receivedAt` cache no longer slides `SeenAt` on hits, so busy talkgroups cannot keep dropping consecutive real calls.
- Cache path now requires similar audio duration (same guard the DB path already used).
- DB `receivedAt` window is anchored to the call’s `ReceivedAt` when set.

## Test plan
- [ ] Two near-simultaneous same-length uploads on one TG → one kept as duplicate
- [ ] Busy TG: short call then long call within 1s → both kept
- [ ] After a duplicate, a new different call just after the 1s window is kept (no sticky window)
- [ ] Confirm no hash/timestamp duplicate log lines on ingest