### PR TITLE
Show unit alias and radio ID during playback

### DIFF
--- a/client/src/app/components/rdio-scanner/console/console.component.html
+++ b/client/src/app/components/rdio-scanner/console/console.component.html
@@ -142,7 +142,7 @@
                   <span class="cell-v">{{ call ? displayTgidForCall(call) : '—' }}</span>
                 </div>
                 <div class="now-cell">
-                  <span class="cell-k">Source</span>
+                  <span class="cell-k">Unit</span>
                   <span class="cell-v">{{ call ? displaySourceForNowPlaying(call) : '—' }}</span>
                 </div>
               </div>
@@ -281,7 +281,7 @@
                             <th>System</th>
                             <th>Talkgroup</th>
                             <th>TGID</th>
-                            <th>Source</th>
+                            <th>Unit</th>
                             <th>MHz</th>
                           </tr>
                         </thead>

--- a/client/src/app/components/rdio-scanner/console/console.component.ts
+++ b/client/src/app/components/rdio-scanner/console/console.component.ts
@@ -47,7 +47,7 @@ import { RdioScannerSupportComponent } from '../main/support/support.component';
 import { SettingsService } from '../settings/settings.service';
 import { TagColorService } from '../tag-color.service';
 import { TranscriptAnnotation, renderAnnotatedTranscript } from '../transcript-utils';
-import { findUnitLabelForSrc, resolveUnitLabelForSrc as resolveUnitLabel } from '../unit-utils';
+import { formatCallUnitDisplay, formatUnitDisplay, resolveUnitLabelForSrc as resolveUnitLabel } from '../unit-utils';
 
 /** Stable index per board tab. Order MUST match the template's `<mat-tab>` list. */
 const TAB = {
@@ -699,17 +699,7 @@ export class RdioScannerConsoleComponent implements OnChanges, OnDestroy, OnInit
     }
 
     displayUnitForCall(call: RdioScannerCall | undefined): string {
-        if (!call) return '—';
-        if (Array.isArray(call.sources) && call.sources.length) {
-            const ordered = [...call.sources].sort((a, b) => (a.pos || 0) - (b.pos || 0));
-            for (const s of ordered) {
-                if (typeof s.tag === 'string' && s.tag.length > 0) return s.tag;
-            }
-            const first = ordered[0];
-            if (typeof first?.src === 'number') return resolveUnitLabel(call.systemData?.units, first.src);
-        }
-        if (typeof call.source === 'number') return resolveUnitLabel(call.systemData?.units, call.source);
-        return '—';
+        return formatCallUnitDisplay(call);
     }
 
     /** Now-playing row prefers the live `callUnit` if it matches; otherwise falls back to the static unit. */
@@ -1243,21 +1233,12 @@ export class RdioScannerConsoleComponent implements OnChanges, OnDestroy, OnInit
                 (p, v) => (v.pos || 0) <= time ? v : p,
                 {} as { pos?: number; src?: number; tag?: string },
             );
-            const firstAlias = this.call.sources
-                .find(s => typeof s.tag === 'string' && s.tag.trim().length > 0)
-                ?.tag?.trim();
 
             if (typeof source.src === 'number') {
-                if (typeof source.tag === 'string' && source.tag.trim().length > 0) {
-                    this.callUnit = source.tag.trim();
-                } else if (firstAlias) {
-                    this.callUnit = firstAlias;
-                } else {
-                    this.callUnit = findUnitLabelForSrc(this.call.systemData?.units, source.src) ?? `${source.src}`;
-                }
+                this.callUnit = formatUnitDisplay(this.call.systemData?.units, source.src, source.tag);
             }
         } else if (typeof this.call.source === 'number') {
-            this.callUnit = findUnitLabelForSrc(this.call.systemData?.units, this.call.source) ?? `${this.call.source}`;
+            this.callUnit = formatUnitDisplay(this.call.systemData?.units, this.call.source);
         }
 
         this.updateCallFlags();
@@ -1289,12 +1270,15 @@ export class RdioScannerConsoleComponent implements OnChanges, OnDestroy, OnInit
                 if (typeof s.src === 'number') {
                     if (norm === String(s.src)) return true;
                     if (norm === resolveUnitLabel(call.systemData?.units, s.src)) return true;
+                    if (norm === formatUnitDisplay(call.systemData?.units, s.src, s.tag)) return true;
                 }
                 if (typeof s.tag === 'string' && s.tag.trim() === norm) return true;
             }
         }
         if (typeof call.source === 'number'
-            && (norm === String(call.source) || norm === resolveUnitLabel(call.systemData?.units, call.source))) {
+            && (norm === String(call.source)
+                || norm === resolveUnitLabel(call.systemData?.units, call.source)
+                || norm === formatUnitDisplay(call.systemData?.units, call.source))) {
             return true;
         }
         return false;

--- a/client/src/app/components/rdio-scanner/search/search.component.html
+++ b/client/src/app/components/rdio-scanner/search/search.component.html
@@ -263,7 +263,7 @@
           </ng-container>
           <ng-container matColumnDef="source">
             <mat-header-cell *matHeaderCellDef>
-              <span>Source</span>
+              <span>Unit</span>
             </mat-header-cell>
             <mat-cell *matCellDef="let row" class="archive-source-cell"
               [matTooltip]="displayUnitForCall(row)"

--- a/client/src/app/components/rdio-scanner/search/search.component.ts
+++ b/client/src/app/components/rdio-scanner/search/search.component.ts
@@ -21,7 +21,7 @@ import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, Vie
 import { FormBuilder } from '@angular/forms';
 import { MatDatepicker } from '@angular/material/datepicker';
 import { BehaviorSubject } from 'rxjs';
-import { resolveUnitLabelForSrc } from '../unit-utils';
+import { formatCallUnitDisplay } from '../unit-utils';
 import {
     RdioScannerCall,
     RdioScannerConfig,
@@ -1223,27 +1223,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         return call.systemData?.type === 'provoice' || call.talkgroupData?.type === 'provoice';
     }
 
-    private resolveUnitLabelForSrc(call: RdioScannerCall, src: number): string {
-        return resolveUnitLabelForSrc(call.systemData?.units, src);
-    }
-
     displayUnitForCall(call: RdioScannerCall | undefined | null): string {
-        if (!call) return '—';
-        if (Array.isArray(call.sources) && call.sources.length) {
-            const ordered = [...call.sources].sort((a, b) => (a.pos || 0) - (b.pos || 0));
-            for (const s of ordered) {
-                if (typeof s.tag === 'string' && s.tag.length > 0) {
-                    return s.tag;
-                }
-            }
-            const first = ordered[0];
-            if (typeof first?.src === 'number') {
-                return this.resolveUnitLabelForSrc(call, first.src);
-            }
-        }
-        if (typeof call.source === 'number') {
-            return this.resolveUnitLabelForSrc(call, call.source);
-        }
-        return '—';
+        return formatCallUnitDisplay(call);
     }
 }

--- a/client/src/app/components/rdio-scanner/unit-utils.ts
+++ b/client/src/app/components/rdio-scanner/unit-utils.ts
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-import { RdioScannerUnit } from './rdio-scanner';
+import { RdioScannerCall, RdioScannerUnit } from './rdio-scanner';
 
 /** True when a configured unit row matches a call source / radio ID. */
 export function unitMatchesSrc(unit: RdioScannerUnit, src: number): boolean {
@@ -50,4 +50,48 @@ export function findUnitLabelForSrc(units: RdioScannerUnit[] | undefined, src: n
 
 export function resolveUnitLabelForSrc(units: RdioScannerUnit[] | undefined, src: number): string {
     return findUnitLabelForSrc(units, src) ?? String(src);
+}
+
+/** Alias plus radio ID, e.g. `Engine 3 | 1234567`, or just the ID when unaliased. */
+export function formatUnitDisplay(units: RdioScannerUnit[] | undefined, src: number, tag?: string): string {
+    if (!(typeof src === 'number') || src <= 0) {
+        const t = tag?.trim();
+        return t && t.length > 0 ? t : '—';
+    }
+    const fromTag = tag?.trim();
+    const alias = fromTag && fromTag !== String(src) ? fromTag : findUnitLabelForSrc(units, src);
+    if (alias && alias !== String(src)) {
+        return `${alias} | ${src}`;
+    }
+    return String(src);
+}
+
+export function formatCallUnitDisplay(call: RdioScannerCall | undefined | null): string {
+    if (!call) {
+        return '—';
+    }
+    if (Array.isArray(call.sources) && call.sources.length) {
+        const ordered = [...call.sources].sort((a, b) => (a.pos || 0) - (b.pos || 0));
+        const parts: string[] = [];
+        const seen = new Set<number>();
+        for (const s of ordered) {
+            if (typeof s.src !== 'number' || s.src <= 0 || seen.has(s.src)) {
+                continue;
+            }
+            seen.add(s.src);
+            parts.push(formatUnitDisplay(call.systemData?.units, s.src, s.tag));
+        }
+        if (parts.length) {
+            return parts.join(', ');
+        }
+        for (const s of ordered) {
+            if (typeof s.tag === 'string' && s.tag.trim().length > 0) {
+                return s.tag.trim();
+            }
+        }
+    }
+    if (typeof call.source === 'number' && call.source > 0) {
+        return formatUnitDisplay(call.systemData?.units, call.source);
+    }
+    return '—';
 }


### PR DESCRIPTION
## Summary
- Now-playing, recent transmissions, and archive search show unit as `alias | radio ID` (or just the ID when there is no alias).
- Live playback updates the unit the same way as the call plays through multiple sources.

Closes #273

Made with [Cursor](https://cursor.com)