### PR TITLE
Restore admin Systems list and reorder

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/config/config.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/config.component.html
@@ -258,7 +258,9 @@
             @case ('systems') {
               <rdio-scanner-admin-systems
                 [form]="systems"
-                (addSystem)="addNewSystem()">
+                [rawSystems]="originalConfig.systems"
+                (addSystem)="addNewSystem()"
+                (selectSystem)="selectSystem($event)">
               </rdio-scanner-admin-systems>
             }
             <!-- Individual system detail view -->

--- a/client/src/app/components/rdio-scanner/admin/config/config.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/config.component.ts
@@ -320,17 +320,15 @@ export class RdioScannerAdminConfigComponent implements OnDestroy, OnInit {
         this.setSection('systems');
     }
 
-    /** Toggle the systems sub-nav; open first system when available */
+    /** Open the systems list (reorder/search). Does not jump into the first system. */
     toggleSystemsSection(): void {
-        this.systemsNavExpanded = !this.systemsNavExpanded;
-        if (this.systemsList.length > 0) {
-            const stillSelected = this.activeSystemForm
-                && this.systems.controls.includes(this.activeSystemForm);
-            this.selectSystem(stillSelected ? this.activeSystemForm! : this.systemsList[0]);
-            return;
+        if (this.activeSection === 'systems') {
+            this.systemsNavExpanded = !this.systemsNavExpanded;
+        } else {
+            this.systemsNavExpanded = true;
+            this.activeSystemForm = null;
+            this.activeSection = 'systems';
         }
-        this.activeSystemForm = null;
-        this.activeSection = 'systems';
         this.ngChangeDetectorRef.markForCheck();
     }
 
@@ -346,7 +344,9 @@ export class RdioScannerAdminConfigComponent implements OnDestroy, OnInit {
     addNewSystem(): void {
         const system = this.adminService.newSystemForm();
         system.markAsDirty({ onlySelf: false });
-        this.systems.insert(0, system);
+        const maxOrder = this.systemsList.reduce((max, s) => Math.max(max, Number(s.value.order) || 0), 0);
+        system.get('order')?.setValue(maxOrder + 1);
+        this.systems.push(system);
         this.form?.markAsDirty();
         this.systemsNavExpanded = true;
         this.activeSystemForm = system;

--- a/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.html
@@ -17,21 +17,120 @@
 * ****************************************************************************
 -->
 <div class="systems-landing">
-  @if (!systems?.length) {
+  <div class="admin-section-bar">
+    <mat-form-field appearance="outline" class="search-field" subscriptSizing="dynamic">
+      <mat-icon matPrefix>search</mat-icon>
+      <input matInput
+        [ngModel]="searchQuery"
+        (ngModelChange)="onSearch($event)"
+        [ngModelOptions]="{standalone: true}"
+        placeholder="Search systems"
+        autocomplete="off">
+      @if (searchQuery) {
+        <button mat-icon-button matSuffix type="button" (click)="onSearch('')" aria-label="Clear search">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+    </mat-form-field>
+    <div class="admin-section-actions">
+      <button type="button" mat-stroked-button
+        (click)="sortAlphabetical()"
+        [disabled]="saving || systems.length < 2"
+        matTooltip="Sort all systems A–Z by name and save">
+        <mat-icon>sort_by_alpha</mat-icon>
+        Sort A–Z
+      </button>
+      <button type="button" mat-stroked-button color="primary" (click)="addSystem.emit()">
+        <mat-icon>add</mat-icon>
+        Add System
+      </button>
+    </div>
+  </div>
+
+  @if (!systems.length) {
     <div class="empty-state">
       <mat-icon>podcasts</mat-icon>
       <p class="mat-body">No systems configured</p>
-      <p class="mat-caption">Add a system from the left panel to get started.</p>
+      <p class="mat-caption">Add a system to get started, or let auto-populate create one from incoming traffic.</p>
       <button type="button" mat-raised-button color="primary" (click)="addSystem.emit()">
         <mat-icon>add</mat-icon>
         Add First System
       </button>
     </div>
-  } @else {
+  } @else if (!filteredSystems.length) {
     <div class="empty-state">
-      <mat-icon>podcasts</mat-icon>
-      <p class="mat-body">Select a system</p>
-      <p class="mat-caption">Choose a system from the left panel to edit it.</p>
+      <mat-icon>search_off</mat-icon>
+      <p class="mat-body">No systems match “{{ searchQuery }}”</p>
+    </div>
+  } @else {
+    <p class="order-hint">
+      Drag the handle to set scanner list order. Clear search to reorder.
+      @if (saving) {
+        <span>Saving…</span>
+      }
+    </p>
+    <div class="table-wrapper">
+      <mat-table [dataSource]="filteredSystems"
+        cdkDropList
+        [cdkDropListData]="filteredSystems"
+        [cdkDropListDisabled]="!!searchQuery.trim()"
+        (cdkDropListDropped)="drop($event)"
+        class="systems-table">
+        <ng-container matColumnDef="drag">
+          <th mat-header-cell *matHeaderCellDef class="drag-col"></th>
+          <td mat-cell *matCellDef="let system" class="drag-col" (click)="$event.stopPropagation()">
+            <mat-icon cdkDragHandle class="drag-handle"
+              [class.drag-disabled]="!!searchQuery.trim()"
+              [matTooltip]="searchQuery.trim() ? 'Clear search to reorder' : 'Drag to reorder'">
+              drag_indicator
+            </mat-icon>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="label">
+          <th mat-header-cell *matHeaderCellDef>System</th>
+          <td mat-cell *matCellDef="let system">
+            <span>{{ system.value.label?.trim() || ('Sys ' + system.value.systemRef) || 'New System' }}</span>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="systemRef">
+          <th mat-header-cell *matHeaderCellDef>ID</th>
+          <td mat-cell *matCellDef="let system">
+            <code>{{ system.value.systemRef || '—' }}</code>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="type">
+          <th mat-header-cell *matHeaderCellDef>Type</th>
+          <td mat-cell *matCellDef="let system">
+            <span>{{ system.value.type || '—' }}</span>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="talkgroups">
+          <th mat-header-cell *matHeaderCellDef>Talkgroups</th>
+          <td mat-cell *matCellDef="let system">{{ talkgroupCount(system) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="sites">
+          <th mat-header-cell *matHeaderCellDef>Sites</th>
+          <td mat-cell *matCellDef="let system">{{ siteCount(system) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef class="actions-col"></th>
+          <td mat-cell *matCellDef="let system" class="actions-col">
+            <button type="button" mat-icon-button
+              matTooltip="Edit system"
+              (click)="selectSystem.emit(system); $event.stopPropagation()">
+              <mat-icon>edit</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+          class="system-row"
+          cdkDrag
+          [cdkDragDisabled]="!!searchQuery.trim()"
+          [cdkDragData]="row"
+          (click)="selectSystem.emit(row)">
+        </tr>
+      </mat-table>
     </div>
   }
 </div>

--- a/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.scss
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.scss
@@ -23,6 +23,46 @@
     min-height: 240px;
 }
 
+.admin-section-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+
+.admin-section-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.search-field {
+    flex: 1 1 220px;
+    max-width: 320px;
+    margin: 0 !important;
+    font-size: 13px;
+
+    ::ng-deep .mat-mdc-form-field-subscript-wrapper { display: none; }
+
+    ::ng-deep .mat-mdc-text-field-wrapper {
+        background: transparent !important;
+        padding-left: 4px;
+    }
+
+    ::ng-deep .mat-mdc-form-field-flex {
+        height: 36px;
+    }
+}
+
+.order-hint {
+    margin: 0 0 8px;
+    color: #888;
+    font-size: 12px;
+}
+
 .empty-state {
     display: flex;
     flex-direction: column;
@@ -50,10 +90,90 @@
 
     .mat-caption {
         color: #666;
-        max-width: 320px;
+        max-width: 360px;
     }
 
     button {
         margin-top: 8px;
     }
+}
+
+.table-wrapper {
+    overflow: auto;
+}
+
+.systems-table {
+    width: 100%;
+    background: transparent;
+
+    .mat-mdc-header-cell,
+    .mat-mdc-cell {
+        color: rgba(255, 255, 255, 0.82);
+    }
+
+    .mat-column-drag {
+        flex: 0 0 36px;
+        width: 36px;
+        padding-left: 4px !important;
+        padding-right: 0 !important;
+    }
+
+    .mat-column-systemRef {
+        flex: 0 0 88px;
+        width: 88px;
+    }
+
+    .mat-column-type {
+        flex: 0 0 120px;
+        width: 120px;
+    }
+
+    .mat-column-talkgroups,
+    .mat-column-sites {
+        flex: 0 0 110px;
+        width: 110px;
+    }
+
+    .mat-column-actions {
+        flex: 0 0 48px;
+        width: 48px;
+        justify-content: flex-end;
+    }
+}
+
+.system-row {
+    cursor: pointer;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.04);
+    }
+}
+
+.drag-handle {
+    color: #555;
+    cursor: grab;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+
+    &:hover { color: #888; }
+
+    &.drag-disabled {
+        opacity: 0.35;
+        cursor: default;
+    }
+}
+
+.cdk-drag-preview {
+    background: #242424;
+    border: 1px solid #444;
+    border-radius: 4px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.cdk-drag-placeholder { opacity: 0.2; }
+
+code {
+    font-size: 12px;
+    color: #9ad;
 }

--- a/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.ts
@@ -105,8 +105,12 @@ export class RdioScannerAdminSystemsComponent {
     }
 
     private async persistOrder(ordered: FormGroup[]): Promise<void> {
+        const previousOrders = ordered.map((system) => ({
+            system,
+            order: system.get('order')?.value,
+        }));
+
         ordered.forEach((system, idx) => system.get('order')?.setValue(idx + 1, { emitEvent: false }));
-        this.form?.markAsDirty();
 
         const orders = ordered
             .map((system, idx) => ({ id: Number(system.get('id')?.value), order: idx + 1 }))
@@ -122,7 +126,9 @@ export class RdioScannerAdminSystemsComponent {
         this.saving = false;
 
         if (saved) {
-            this.form?.markAsPristine();
+            // Order-only save: do not markAsPristine. Admin config rebuilds from
+            // EmitConfig when the form is pristine, which would wipe unsaved
+            // system field edits after a reorder.
             if (this.rawSystems) {
                 for (const item of orders) {
                     const raw = this.rawSystems.find((s) => s.id === item.id);
@@ -133,6 +139,9 @@ export class RdioScannerAdminSystemsComponent {
             }
             this.snackBar.open('System order saved', 'Close', { duration: 1500 });
         } else {
+            for (const item of previousOrders) {
+                item.system.get('order')?.setValue(item.order, { emitEvent: false });
+            }
             this.snackBar.open('Failed to save system order. Please try again.', 'Close', { duration: 4000 });
         }
         this.cdr.markForCheck();

--- a/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.ts
+++ b/client/src/app/components/rdio-scanner/admin/config/systems/systems.component.ts
@@ -18,8 +18,11 @@
  * ****************************************************************************
  */
 
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { RdioScannerAdminService } from '../../admin.service';
 
 @Component({
     selector: 'rdio-scanner-admin-systems',
@@ -30,12 +33,116 @@ import { FormArray, FormGroup } from '@angular/forms';
 })
 export class RdioScannerAdminSystemsComponent {
     @Input() form: FormArray | undefined;
+    @Input() rawSystems: any[] | undefined;
 
-    /** Emitted when the user clicks Add System */
     @Output() addSystem = new EventEmitter<void>();
+    @Output() selectSystem = new EventEmitter<FormGroup>();
+
+    displayedColumns = ['drag', 'label', 'systemRef', 'type', 'talkgroups', 'sites', 'actions'];
+    searchQuery = '';
+    saving = false;
+
+    constructor(
+        private adminService: RdioScannerAdminService,
+        private cdr: ChangeDetectorRef,
+        private snackBar: MatSnackBar,
+    ) { }
 
     get systems(): FormGroup[] {
-        if (!this.form) return [];
-        return this.form.controls as FormGroup[];
+        if (!this.form) {
+            return [];
+        }
+        return (this.form.controls as FormGroup[])
+            .slice()
+            .sort((a, b) => (a.value.order || 0) - (b.value.order || 0)
+                || String(a.value.label || '').localeCompare(String(b.value.label || '')));
+    }
+
+    get filteredSystems(): FormGroup[] {
+        const q = this.searchQuery.trim().toLowerCase();
+        if (!q) {
+            return this.systems;
+        }
+        return this.systems.filter((system) => {
+            const label = String(system.value.label || '').toLowerCase();
+            const ref = String(system.value.systemRef ?? '');
+            const type = String(system.value.type || '').toLowerCase();
+            return label.includes(q) || ref.includes(q) || type.includes(q);
+        });
+    }
+
+    onSearch(query: string): void {
+        this.searchQuery = query;
+        this.cdr.markForCheck();
+    }
+
+    talkgroupCount(system: FormGroup): number {
+        const raw = this.rawFor(system);
+        return raw?.talkgroups?.length ?? system.value.talkgroups?.length ?? 0;
+    }
+
+    siteCount(system: FormGroup): number {
+        const raw = this.rawFor(system);
+        return raw?.sites?.length ?? system.value.sites?.length ?? 0;
+    }
+
+    drop(event: CdkDragDrop<FormGroup[]>): void {
+        if (this.searchQuery.trim() || event.previousIndex === event.currentIndex) {
+            return;
+        }
+        const all = this.systems;
+        if (event.previousIndex < 0 || event.previousIndex >= all.length) {
+            return;
+        }
+        moveItemInArray(all, event.previousIndex, Math.min(event.currentIndex, all.length - 1));
+        void this.persistOrder(all);
+    }
+
+    sortAlphabetical(): void {
+        const all = this.systems.slice().sort((a, b) =>
+            String(a.value.label || '').localeCompare(String(b.value.label || ''), undefined, { sensitivity: 'base' }));
+        void this.persistOrder(all);
+    }
+
+    private async persistOrder(ordered: FormGroup[]): Promise<void> {
+        ordered.forEach((system, idx) => system.get('order')?.setValue(idx + 1, { emitEvent: false }));
+        this.form?.markAsDirty();
+
+        const orders = ordered
+            .map((system, idx) => ({ id: Number(system.get('id')?.value), order: idx + 1 }))
+            .filter((item) => item.id > 0);
+        if (!orders.length) {
+            this.cdr.markForCheck();
+            return;
+        }
+
+        this.saving = true;
+        this.cdr.markForCheck();
+        const saved = await this.adminService.saveSystemsOrder(orders);
+        this.saving = false;
+
+        if (saved) {
+            this.form?.markAsPristine();
+            if (this.rawSystems) {
+                for (const item of orders) {
+                    const raw = this.rawSystems.find((s) => s.id === item.id);
+                    if (raw) {
+                        raw.order = item.order;
+                    }
+                }
+            }
+            this.snackBar.open('System order saved', 'Close', { duration: 1500 });
+        } else {
+            this.snackBar.open('Failed to save system order. Please try again.', 'Close', { duration: 4000 });
+        }
+        this.cdr.markForCheck();
+    }
+
+    private rawFor(system: FormGroup): any | undefined {
+        const id = system.value.id;
+        if (!id || !this.rawSystems) {
+            return undefined;
+        }
+        return this.rawSystems.find((s) => s.id === id);
     }
 }

--- a/server/controller.go
+++ b/server/controller.go
@@ -567,6 +567,14 @@ func (controller *Controller) IngestCall(call *Call) {
 			system.Label = fmt.Sprintf("System %v", systemId)
 		}
 
+		maxOrder := uint(0)
+		for _, existing := range controller.Systems.List {
+			if existing != nil && existing.Order > maxOrder {
+				maxOrder = existing.Order
+			}
+		}
+		system.Order = maxOrder + 1
+
 		controller.Systems.List = append(controller.Systems.List, system)
 	}
 


### PR DESCRIPTION
## Summary
- Clicking **Systems** opens a list of all systems instead of jumping into the first one.
- Drag-and-drop and **Sort A–Z** persist order through `PUT /api/admin/systems/order`.
- Newly auto-populated systems are appended at the end instead of stacking at the top.

Closes #276

Made with [Cursor](https://cursor.com)